### PR TITLE
Fix typo (duplicate word)

### DIFF
--- a/jupyter-book/introduction/raw_data_processing.md
+++ b/jupyter-book/introduction/raw_data_processing.md
@@ -326,7 +326,7 @@ Here we define the following functions on the node $v_i \in V$:
 
 - $u(v_i)$ is the UMI tag of $v_i$.
 - $c(v_i) = |v_i|$ is the cardinality of $v_i$, i.e., the number of reads associated with $v_i$ that are equivalent under $\sim_r$.
-- $m(v_i)$ is the reference set encoded in the the mapping information, for $v_i$.
+- $m(v_i)$ is the reference set encoded in the mapping information, for $v_i$.
 - $D(v_i, v_j)$ is the distance between $u(v_i)$ and $u(v_j)$, where $v_j \in V$.
 
 Given these function definitions, any two nodes $v_i, v_j \in V$ will be incident with a bi-directed edge if and only if $m(v_i) \cap m(v_j) \ne \emptyset$ and $D(v_i,v_j) \le \theta$, where $\theta$ is a distance threshold and is often set as $\theta=1${cite}`Smith2017,Kaminow2021,Srivastava2019`. Additionally, the bi-directed edge might be replaced by a directed edge incident from $v_i$ to $v_j$ if $c(v_i) \ge 2c(v_j) -1$ or vice versa{cite}`Smith2017,Srivastava2019`. Though these edge definitions are among the most common, others are possible, so long as they are completely defined by the $u$, $c$, $m$, and $D$ functions. With $V$ and $E$ in hand, the UMI graph $G = (V,E)$ is now defined.


### PR DESCRIPTION
This PR fixes simple fixes a typo, i.e. a duplication of the word `the`.