### PR TITLE
Changed regex for calculation of percent hemoglobin genes

### DIFF
--- a/jupyter-book/preprocessing_visualization/quality_control.ipynb
+++ b/jupyter-book/preprocessing_visualization/quality_control.ipynb
@@ -205,7 +205,7 @@
     "# ribosomal genes\n",
     "adata.var[\"ribo\"] = adata.var_names.str.startswith((\"RPS\", \"RPL\"))\n",
     "# hemoglobin genes.\n",
-    "adata.var[\"hb\"] = adata.var_names.str.contains((\"^HB[^(P)]\"))"
+    "adata.var[\"hb\"] = adata.var_names.str.contains((\"^HB(?!EGF|S1L|P1).+\"))"
    ]
   },
   {


### PR DESCRIPTION
Dear Theis lab,

thank you a lot for your very helpful book and tutorials. 

I am currently performing my first analysis of scRNAseq data. During step 6.3 (filtering low quality reads) I wanted to understand the regex for filtering hemoglobin genes ("^HB[^(P)]"). 
I noticed that this regex not only includes hemoglobin-genes, but also the genes [HBEGF](https://www.ncbi.nlm.nih.gov/gene/1839), [HBS1L](https://www.ncbi.nlm.nih.gov/gene/10767), and [HBP1](https://www.ncbi.nlm.nih.gov/gene?Db=gene&Cmd=DetailsSearch&Term=26959). 

I was trying to find a more specific regex to match only the hemoglobin genes, with some help from [stackoverflow](https://stackoverflow.com/questions/76904231/regular-expression-for-hemoglobulin-genes). I'd suggest `"^HB(?!EGF|S1L|P1).+"`, which I changed in the jupyter notebook, an alternative might be `"^HB[^(P|S)]($|[^G])"`. 

This applies to human data, however we briefly confirmed that these regexs are applicable (with lowercase characters) to mouse data, too. 

Please correct me if I am wrong and the original regex performs in the way intended by you. In this case, I would suggest extending the documentation for clarification. 

Best,

Kristina

edit: added code backticks to the suggested regexs for correct display