### PR TITLE
Update environment name for consistency

### DIFF
--- a/jupyter-book/cellular_structure/annotation.yml
+++ b/jupyter-book/cellular_structure/annotation.yml
@@ -1,4 +1,4 @@
-name: best_practices_annotation
+name: annotation
 
 channels:
   - conda-forge


### PR DESCRIPTION
The env name should be consistent to other env names such as `preprocessing`, `clustering`, `integration`, etc.