### PR TITLE
Add manual for using towncrier in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,57 @@ All chapters are available as Jupyter Notebooks and end-to-end executable.
 The diverse requirements of tools for the chapters do not allow it for us to provide a single environment that can build all chapters.
 Hence, we decided to provide minimal Conda environments per chapter. These can be found in the respective folders.
 
+## Adding changelog entries with `towncrier`
+
+We use `towncrier` to manage our changelog. Here’s how to include a changelog entry when making a PR:
+
+1. Install `towncrier` (only once):
+
+```bash
+pip install towncrier
+```
+
+2. Make your pull request as usual.
+
+3. After opening your PR, note the PR number (e.g., 34), and create a changelog fragment:
+
+```bash
+towncrier create -c "update blah blah" 34.changed.md
+```
+
+Replace "update blah blah" with a brief description of your change.
+Valid categories are:
+
+`added`
+`changed`
+`fixed`
+`removed`
+
+4. This will create a `.md` file (e.g., `34.changed.md`) in the `changelog.d/` directory (at the root of the repo). Make sure this file is included in your commit.
+
+5. Push your changes again. Once your PR is reviewed, it can be merged!
+
+### Releasing a new version (maintainers only)
+
+To release a new version:
+
+1. Run Towncrier to build the changelog:
+
+```bash
+towncrier build --yes --version 2.0.0
+```
+
+This will update `CHANGELOG.md` and remove the `changelog.d/` directory.
+
+2. Add contributor names manually under each relevant PR entry in the generated `CHANGELOG.md`.
+
+3. Recreate the `changelog.d/` directory for future PRs:
+
+```bash
+mkdir changelog.d
+touch changelog.d/.gitkeep
+```
+
 ## Environment setup
 
 Run the following command with the environment file of choice to create the environment for the chapter that you want to build.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,11 +90,11 @@ pip install towncrier
 3. After opening your PR, note the PR number (e.g., 34), and create a changelog fragment:
 
 ```bash
-towncrier create -c "update blah blah" 34.changed.md
+towncrier create -c 'update blah blah ([#34](https://github.com/theislab/single-cell-best-practices/pull/34)) <sub>@seohyonkim</sub>' 34.changed.md
 ```
 
-Replace "update blah blah" with a brief description of your change.
-Valid categories are:
+Replace "update blah blah" with a brief description of your change, PR number with your PR number, and the author of the PR with your github tag.
+Valid categories for the filename of the `markdown` are:
 
 `added`
 `changed`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ towncrier build --yes --version 2.0.0
 
 This will update `CHANGELOG.md` and remove the `changelog.d/` directory.
 
-2. Add contributor names manually under each relevant PR entry in the generated `CHANGELOG.md`.
+2. Add contributor names and links to the PR manually under each relevant PR entry in the generated `CHANGELOG.md`.
 
 3. Recreate the `changelog.d/` directory for future PRs:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ Valid categories for the filename of the `markdown` are:
 
 4. This will create a `.md` file (e.g., `34.changed.md`) in the `changelog.d/` directory (at the root of the repo). Make sure this file is included in your commit.
 
-5. Push your changes again. Once your PR is reviewed, it can be merged!
+5. Push your changes again.
 
 ### Releasing a new version (maintainers only)
 

--- a/changelog.d/345.added.md
+++ b/changelog.d/345.added.md
@@ -1,1 +1,1 @@
-Add new feature `changelog`. Changelog fragments will be added in `changelog` chapter.
+Add new feature `changelog`. Changelog fragments will be added in `changelog` chapter. ([#345](https://github.com/theislab/single-cell-best-practices/pull/345)) <sub>@seohyonkim</sub>

--- a/changelog.d/347.changed.md
+++ b/changelog.d/347.changed.md
@@ -1,1 +1,1 @@
-Add dataset generator and updatae texts in `Interoperability` chapter
+Add dataset generator and updatae texts in `Interoperability` chapter. ([#347](https://github.com/theislab/single-cell-best-practices/pull/347)) <sub>@seohyonkim</sub>

--- a/changelog.d/348.added.md
+++ b/changelog.d/348.added.md
@@ -1,1 +1,1 @@
-Add env- and lamin-setup dropdown with `make dropdown`
+Add env- and lamin-setup dropdown with `make dropdown`. ([#348](https://github.com/theislab/single-cell-best-practices/pull/348)) <sub>@LuisHenzlmeier</sub>

--- a/changelog.d/351.added.md
+++ b/changelog.d/351.added.md
@@ -1,1 +1,1 @@
-Add manual to use `towncrier` in `CONTRIBUTING.md`.
+Add manual to use `towncrier` in `CONTRIBUTING.md`. ([#351](https://github.com/theislab/single-cell-best-practices/pull/351)) <sub>@seohyonkim</sub>

--- a/changelog.d/351.added.md
+++ b/changelog.d/351.added.md
@@ -1,0 +1,1 @@
+Add manual to use `towncrier` in `CONTRIBUTING.md`.


### PR DESCRIPTION
In this PR, I added how the contributers can use `towncrier` to document the changes we apply to the book. The manual is in the document `CONTRIBUTING.md`.