### PR TITLE
Quick fix of updating precommit action to v3.0.0

### DIFF
--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-      - uses: pre-commit/action@v2.0.0
+      - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
This is a quick fix where the `pre-commit` version is updated from `2.0.0` to `3.0.0`, due to the service shutting down.
`.github/workflows/pre_commit.yml` file is changed.