### PR TITLE
Fix scran normalization: use raw counts for computeSumFactors

### DIFF
--- a/jupyter-book/preprocessing_visualization/normalization.ipynb
+++ b/jupyter-book/preprocessing_visualization/normalization.ipynb
@@ -339,7 +339,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_mat = adata_pp.X.T\n",
+    "# IMPORTANT: scran's computeSumFactors requires raw counts (not normalized or log-transformed).\n",
+    "# adata_pp.X is log-normalized and used only for clustering, so we pass the original counts here instead.\n",
+    "data_mat = adata.layers[\"counts\"].T\n",
     "# convert to CSC if possible. See https://github.com/MarioniLab/scran/issues/70\n",
     "if issparse(data_mat):\n",
     "    if data_mat.nnz > 2**31 - 1:\n",


### PR DESCRIPTION
The current notebook passes log-normalized data (adata_pp.X) to computeSumFactors as counts, which is inconsistent with scran's requirements.

computeSumFactors expects raw counts, while adata_pp.X is only intended for coarse clustering. This change uses adata.layers["counts"] as input for size factor estimation and adds a clarifying comment.

Related to #186