### PR TITLE
Bound DataFrame preview in data-structures chapter (fixes #126)

### DIFF
--- a/jupyter-book/introduction/fundamental_data_structures_and_frameworks.ipynb
+++ b/jupyter-book/introduction/fundamental_data_structures_and_frameworks.ipynb
@@ -3592,7 +3592,8 @@
     }
    ],
    "source": [
-    "adata.to_df(layer=\"log_transformed\")"
+    "with pd.option_context(\"display.max_columns\", 10):\n",
+    "    display(adata.to_df(layer=\"log_transformed\"))"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Wraps the `adata.to_df(layer="log_transformed")` preview in the "Conversion to DataFrames" section with `pd.option_context("display.max_columns", 10)` so pandas inserts a `...` instead of rendering the full ~2000-gene DataFrame past the right margin (#126).