### PR TITLE
Add intersphinx mapping and hyperlink API mentions (fixes #128)

### DIFF
--- a/jupyter-book/_config.yml
+++ b/jupyter-book/_config.yml
@@ -47,6 +47,8 @@ latex:
 notebook_interface: "notebook"
 
 sphinx:
+  extra_extensions:
+    - sphinx.ext.intersphinx
   config:
     nb_custom_formats:
       .py:
@@ -58,6 +60,47 @@ sphinx:
       - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js
     bibtex_reference_style: author_year
     language: en
+    # Missing cross-references are warnings, not errors — many backticks in
+    # the book reference instance attributes (e.g. `adata.obs`) that have no
+    # canonical API object to link to.
+    nitpicky: false
+    intersphinx_mapping:
+      python: ["https://docs.python.org/3", null]
+      numpy: ["https://numpy.org/doc/stable", null]
+      pandas: ["https://pandas.pydata.org/docs", null]
+      scipy: ["https://docs.scipy.org/doc/scipy", null]
+      matplotlib: ["https://matplotlib.org/stable", null]
+      seaborn: ["https://seaborn.pydata.org", null]
+      sklearn: ["https://scikit-learn.org/stable", null]
+      ipython: ["https://ipython.readthedocs.io/en/stable", null]
+      rpy2: ["https://rpy2.github.io/doc/latest/html", null]
+      anndata: ["https://anndata.readthedocs.io/en/stable", null]
+      scanpy: ["https://scanpy.readthedocs.io/en/stable", null]
+      mudata: ["https://mudata.readthedocs.io/stable", null]
+      muon: ["https://muon.readthedocs.io/en/stable", null]
+      squidpy: ["https://squidpy.readthedocs.io/en/stable", null]
+      spatialdata: ["https://spatialdata.scverse.org/en/stable", null]
+      scirpy: ["https://scirpy.scverse.org/en/stable", null]
+      scvi: ["https://docs.scvi-tools.org/en/stable", null]
+      scarches: ["https://scarches.readthedocs.io/en/latest", null]
+      pertpy: ["https://pertpy.readthedocs.io/en/latest", null]
+      decoupler: ["https://decoupler.readthedocs.io/en/latest", null]
+      liana: ["https://liana-py.readthedocs.io/en/latest", null]
+      omnipath: ["https://omnipath.readthedocs.io/en/latest", null]
+      scvelo: ["https://scvelo.readthedocs.io/en/stable", null]
+      cellrank: ["https://cellrank.readthedocs.io/en/stable", null]
+      palantir: ["https://palantir.readthedocs.io/en/latest", null]
+      dynamo: ["https://dynamo-release.readthedocs.io/en/latest", null]
+      hotspot: ["https://hotspot.readthedocs.io/en/latest", null]
+      cell2location: ["https://cell2location.readthedocs.io/en/latest", null]
+      tangram: ["https://tangram-sc.readthedocs.io/en/latest", null]
+      pydeseq2: ["https://pydeseq2.readthedocs.io/en/latest", null]
+      celltypist: ["https://celltypist.readthedocs.io/en/latest", null]
+      scib: ["https://scib.readthedocs.io/en/latest", null]
+      lamindb: ["https://docs.lamin.ai", null]
+      rapids_singlecell:
+        ["https://rapids-singlecell.readthedocs.io/en/latest", null]
+      cassiopeia: ["https://cassiopeia.readthedocs.io/en/latest", null]
 
 bibtex_bibfiles:
   - preamble.bib

--- a/jupyter-book/_static/default_text_lamindb_setup.md
+++ b/jupyter-book/_static/default_text_lamindb_setup.md
@@ -33,7 +33,7 @@ We acknowledge free hosting from [Lamin Labs](https://lamin.ai/).
    ```
 
    The object is now accessible in memory and is ready for analysis.
-   Adapt the `ln.Artifact.connect("theislab/sc-best-practices").get("SOMEIDXXXX")` suffix to get respective versions.
+   Adapt the {py:obj}`lamindb.Artifact.connect`("theislab/sc-best-practices").get("SOMEIDXXXX") suffix to get respective versions.
 
 5. **Accessing notebooks (Transforms)**
    - Search for the notebook on the [Transforms page](https://lamin.ai/theislab/sc-best-practices/transforms)

--- a/jupyter-book/_static/default_text_lamindb_setup.md
+++ b/jupyter-book/_static/default_text_lamindb_setup.md
@@ -33,7 +33,7 @@ We acknowledge free hosting from [Lamin Labs](https://lamin.ai/).
    ```
 
    The object is now accessible in memory and is ready for analysis.
-   Adapt the {py:obj}`lamindb.Artifact.connect`("theislab/sc-best-practices").get("SOMEIDXXXX") suffix to get respective versions.
+   Adapt the {py:meth}`lamindb.Artifact.connect("theislab/sc-best-practices").get("SOMEIDXXXX") <lamindb.Artifact.connect>` suffix to get respective versions.
 
 5. **Accessing notebooks (Transforms)**
    - Search for the notebook on the [Transforms page](https://lamin.ai/theislab/sc-best-practices/transforms)

--- a/jupyter-book/cellular_structure/clustering.ipynb
+++ b/jupyter-book/cellular_structure/clustering.ipynb
@@ -84,7 +84,7 @@
     "```{admonition} Running this on a GPU\n",
     ":class: tip, dropdown\n",
     "Leiden clustering on a million-cell graph is one of the worst CPU bottlenecks in a typical pipeline and one of the best GPU wins.\n",
-    "[rapids-singlecell](../introduction/rapids_singlecell.ipynb) provides `rsc.tl.leiden` with the same signature and routinely runs 50\u2013100\u00d7 faster than the CPU implementation.\n",
+    "[rapids-singlecell](../introduction/rapids_singlecell.ipynb) provides {py:obj}`rapids_singlecell.tl.leiden` with the same signature and routinely runs 50–100× faster than the CPU implementation.\n",
     "```"
    ]
   },
@@ -98,8 +98,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[92m\u2192\u001b[0m loaded Transform('rJhR7SskiROg0000', key='clustering.ipynb'), re-started Run('LZOdfrBECJI7FQWH4MFl') at 2026-02-16 13:15:47 UTC\n",
-      "\u001b[92m\u2192\u001b[0m notebook imports: lamindb==2.0.1 scanpy==1.11.5\n"
+      "\u001b[92m→\u001b[0m loaded Transform('rJhR7SskiROg0000', key='clustering.ipynb'), re-started Run('LZOdfrBECJI7FQWH4MFl') at 2026-02-16 13:15:47 UTC\n",
+      "\u001b[92m→\u001b[0m notebook imports: lamindb==2.0.1 scanpy==1.11.5\n"
      ]
     }
    ],
@@ -152,7 +152,7 @@
    "metadata": {},
    "source": [
     "The Leiden algorithm leverages a KNN graph on the reduced expression space.\n",
-    "We can calculate the KNN graph on a lower-dimensional gene expression representation with the scanpy function `sc.pp.neighbors`.\n",
+    "We can calculate the KNN graph on a lower-dimensional gene expression representation with the scanpy function {py:obj}`scanpy.pp.neighbors`.\n",
     "We call this function on the top 30 principal-components as these capture most of the variance in the dataset.\n",
     "Visualizing the clustering can help us to understand the results, we therefore embed our cells into a UMAP embedding.\n",
     "More details can be found in the [dimensionality reduction chapter](../preprocessing_visualization/dimensionality_reduction.ipynb)."
@@ -194,7 +194,7 @@
    "source": [
     "```{admonition} Optimizing Leiden Iterations\n",
     ":class: dropdown\n",
-    "The `n_iterations` parameter in `sc.tl.leiden()` determines how many refinement passes the algorithm performs to optimize its community detection.\n",
+    "The `n_iterations` parameter in {py:obj}`scanpy.tl.leiden`() determines how many refinement passes the algorithm performs to optimize its community detection.\n",
     "\n",
     "* **`n_iterations = 2` (Recommended):** The standard choice for most analyses.\n",
     "It offers a significant boost in cluster quality over the Louvain algorithm while remaining computationally efficient.\n",
@@ -312,14 +312,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[92m\u2192\u001b[0m writing the in-memory object into cache\n"
+      "\u001b[92m→\u001b[0m writing the in-memory object into cache\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[92m\u2192\u001b[0m returning artifact with same hash: Artifact(uid='UIb3nBOY3Xcejedh0003', version_tag=None, is_latest=True, key='cellular_structure/s4d8_clustered.h5ad', description='anndata after clustering', suffix='.h5ad', kind='dataset', otype='AnnData', size=364819346, hash='20SV0Ax1_Ot0qHUM0DgM9Q', n_files=None, n_observations=8874, branch_id=1, space_id=1, storage_id=1, run_id=11, schema_id=None, created_by_id=5, created_at=2026-02-16 14:57:06 UTC, is_locked=False); to track this artifact as an input, use: ln.Artifact.get()\n"
+      "\u001b[92m→\u001b[0m returning artifact with same hash: Artifact(uid='UIb3nBOY3Xcejedh0003', version_tag=None, is_latest=True, key='cellular_structure/s4d8_clustered.h5ad', description='anndata after clustering', suffix='.h5ad', kind='dataset', otype='AnnData', size=364819346, hash='20SV0Ax1_Ot0qHUM0DgM9Q', n_files=None, n_observations=8874, branch_id=1, space_id=1, storage_id=1, run_id=11, schema_id=None, created_by_id=5, created_at=2026-02-16 14:57:06 UTC, is_locked=False); to track this artifact as an input, use: ln.Artifact.get()\n"
      ]
     },
     {

--- a/jupyter-book/cellular_structure/clustering.ipynb
+++ b/jupyter-book/cellular_structure/clustering.ipynb
@@ -84,7 +84,7 @@
     "```{admonition} Running this on a GPU\n",
     ":class: tip, dropdown\n",
     "Leiden clustering on a million-cell graph is one of the worst CPU bottlenecks in a typical pipeline and one of the best GPU wins.\n",
-    "[rapids-singlecell](../introduction/rapids_singlecell.ipynb) provides {py:obj}`rapids_singlecell.tl.leiden` with the same signature and routinely runs 50–100× faster than the CPU implementation.\n",
+    "[rapids-singlecell](../introduction/rapids_singlecell.ipynb) provides {py:func}`rapids_singlecell.tl.leiden` with the same signature and routinely runs 50–100× faster than the CPU implementation.\n",
     "```"
    ]
   },
@@ -152,7 +152,7 @@
    "metadata": {},
    "source": [
     "The Leiden algorithm leverages a KNN graph on the reduced expression space.\n",
-    "We can calculate the KNN graph on a lower-dimensional gene expression representation with the scanpy function {py:obj}`scanpy.pp.neighbors`.\n",
+    "We can calculate the KNN graph on a lower-dimensional gene expression representation with the scanpy function {py:func}`scanpy.pp.neighbors`.\n",
     "We call this function on the top 30 principal-components as these capture most of the variance in the dataset.\n",
     "Visualizing the clustering can help us to understand the results, we therefore embed our cells into a UMAP embedding.\n",
     "More details can be found in the [dimensionality reduction chapter](../preprocessing_visualization/dimensionality_reduction.ipynb)."
@@ -194,7 +194,7 @@
    "source": [
     "```{admonition} Optimizing Leiden Iterations\n",
     ":class: dropdown\n",
-    "The `n_iterations` parameter in {py:obj}`scanpy.tl.leiden`() determines how many refinement passes the algorithm performs to optimize its community detection.\n",
+    "The `n_iterations` parameter in {py:func}`scanpy.tl.leiden() <scanpy.tl.leiden>` determines how many refinement passes the algorithm performs to optimize its community detection.\n",
     "\n",
     "* **`n_iterations = 2` (Recommended):** The standard choice for most analyses.\n",
     "It offers a significant boost in cluster quality over the Louvain algorithm while remaining computationally efficient.\n",

--- a/jupyter-book/chromatin_accessibility/quality_control.ipynb
+++ b/jupyter-book/chromatin_accessibility/quality_control.ipynb
@@ -516,7 +516,7 @@
    "source": [
     "Based on the output messages about 18% of cells are suggested to be doublets. This might sound like a high fraction, but for the number of cells loaded for this sample and since isolated nuclei tend to stick together, this is reasonable.\n",
     "\n",
-    "Once the calculation is done, let's create a `pandas.DataFrame` containing the scores for all barcodes and save it as a file."
+    "Once the calculation is done, let's create a {py:obj}`pandas.DataFrame` containing the scores for all barcodes and save it as a file."
    ]
   },
   {

--- a/jupyter-book/chromatin_accessibility/quality_control.ipynb
+++ b/jupyter-book/chromatin_accessibility/quality_control.ipynb
@@ -516,7 +516,7 @@
    "source": [
     "Based on the output messages about 18% of cells are suggested to be doublets. This might sound like a high fraction, but for the number of cells loaded for this sample and since isolated nuclei tend to stick together, this is reasonable.\n",
     "\n",
-    "Once the calculation is done, let's create a {py:obj}`pandas.DataFrame` containing the scores for all barcodes and save it as a file."
+    "Once the calculation is done, let's create a {py:class}`pandas.DataFrame` containing the scores for all barcodes and save it as a file."
    ]
   },
   {

--- a/jupyter-book/conditions/compositional.ipynb
+++ b/jupyter-book/conditions/compositional.ipynb
@@ -1319,7 +1319,7 @@
     }
    },
    "source": [
-    "To use tascCODA, we first have to define a hierarchical ordering of the cell types. One possible hierarchical clustering uses the eight cell types and orders them by their similarity (pearson correlation) in the PCA representation with {py:obj}`scanpy.tl.dendrogram`.\n",
+    "To use tascCODA, we first have to define a hierarchical ordering of the cell types. One possible hierarchical clustering uses the eight cell types and orders them by their similarity (pearson correlation) in the PCA representation with {py:func}`scanpy.tl.dendrogram`.\n",
     "Since this structure is very simple in our data and will therefore not give us many new insights, we want to have a more complex clustering. One recent method to get such clusters, is the [schist](https://github.com/dawe/schist) package {cite}`Morelli2021`, which uses a nested stochastic block model that clusters the cell population at different resolution levels. Running the method with standard settings takes some time (~15 minutes on our data), and gives us an assignment of each cell to a hierarchical clustering in `adata.obs`.\n",
     "First, we need to define a distance measure between the cells through a PCA embedding:"
    ]
@@ -3294,7 +3294,7 @@
    "source": [
     "Milo is a KNN-based model, where cell abundance is quantified on neighbourhoods of cells. In Milo, a neighbourhood is defined as the group of cells connected by an edge to the same cell (_index cell_) in an undirected KNN graph. While we could in principle have one neighbourhood for each cell in the graph, this would be inefficient and significantly increase the multiple testing burden. Therefore Milo samples a refined set of cells as index cells for neighbourhoods, starting from a random sample of a fraction of cells. The initial proportion can be specified using the `prop` argument in the `milo.make_nhoods` function. As by default, we recommend using `prop=0.1` (10% of cells) and to reduce to 5% or 2% to increase scalability on large datasets (> 100k cells).\n",
     "\n",
-    "If no `neighbors_key` parameter is specified, Milo uses the neighbours from `.obsp`. Therefore, ensure that {py:obj}`scanpy.pp.neighbors` was run on the correct representation, i.e. an integrated latent space if batch correction was required."
+    "If no `neighbors_key` parameter is specified, Milo uses the neighbours from `.obsp`. Therefore, ensure that {py:func}`scanpy.pp.neighbors` was run on the correct representation, i.e. an integrated latent space if batch correction was required."
    ]
   },
   {

--- a/jupyter-book/conditions/compositional.ipynb
+++ b/jupyter-book/conditions/compositional.ipynb
@@ -1319,7 +1319,7 @@
     }
    },
    "source": [
-    "To use tascCODA, we first have to define a hierarchical ordering of the cell types. One possible hierarchical clustering uses the eight cell types and orders them by their similarity (pearson correlation) in the PCA representation with `sc.tl.dendrogram`.\n",
+    "To use tascCODA, we first have to define a hierarchical ordering of the cell types. One possible hierarchical clustering uses the eight cell types and orders them by their similarity (pearson correlation) in the PCA representation with {py:obj}`scanpy.tl.dendrogram`.\n",
     "Since this structure is very simple in our data and will therefore not give us many new insights, we want to have a more complex clustering. One recent method to get such clusters, is the [schist](https://github.com/dawe/schist) package {cite}`Morelli2021`, which uses a nested stochastic block model that clusters the cell population at different resolution levels. Running the method with standard settings takes some time (~15 minutes on our data), and gives us an assignment of each cell to a hierarchical clustering in `adata.obs`.\n",
     "First, we need to define a distance measure between the cells through a PCA embedding:"
    ]
@@ -3294,7 +3294,7 @@
    "source": [
     "Milo is a KNN-based model, where cell abundance is quantified on neighbourhoods of cells. In Milo, a neighbourhood is defined as the group of cells connected by an edge to the same cell (_index cell_) in an undirected KNN graph. While we could in principle have one neighbourhood for each cell in the graph, this would be inefficient and significantly increase the multiple testing burden. Therefore Milo samples a refined set of cells as index cells for neighbourhoods, starting from a random sample of a fraction of cells. The initial proportion can be specified using the `prop` argument in the `milo.make_nhoods` function. As by default, we recommend using `prop=0.1` (10% of cells) and to reduce to 5% or 2% to increase scalability on large datasets (> 100k cells).\n",
     "\n",
-    "If no `neighbors_key` parameter is specified, Milo uses the neighbours from `.obsp`. Therefore, ensure that `sc.pp.neighbors` was run on the correct representation, i.e. an integrated latent space if batch correction was required."
+    "If no `neighbors_key` parameter is specified, Milo uses the neighbours from `.obsp`. Therefore, ensure that {py:obj}`scanpy.pp.neighbors` was run on the correct representation, i.e. an integrated latent space if batch correction was required."
    ]
   },
   {

--- a/jupyter-book/conditions/differential_gene_expression.ipynb
+++ b/jupyter-book/conditions/differential_gene_expression.ipynb
@@ -642,7 +642,7 @@
    "source": [
     "While thresholds are dataset-specific and arbitrary, a commonly used guideline is to retain samples with a minimum of 10 cells and 1,000 total counts. \n",
     "Applying these thresholds (indicated by dashed lines) restricts the dataset to pseudobulks in the upper-right quadrant. \n",
-    "The filtering step can be carried out with {py:obj}`decoupler.pp.filter_samples`()."
+    "The filtering step can be carried out with {py:func}`decoupler.pp.filter_samples() <decoupler.pp.filter_samples>`."
    ]
   },
   {
@@ -906,9 +906,9 @@
    "source": [
     "Two strategies are used to filter genes:\n",
     "\n",
-    "1. {py:obj}`decoupler.pp.filter_by_expr`: Retains genes with a minimum total number of reads across all samples (`min_total_count`) and a minimum number of counts in a given number of samples (`min_count`). \n",
+    "1. {py:func}`decoupler.pp.filter_by_expr`: Retains genes with a minimum total number of reads across all samples (`min_total_count`) and a minimum number of counts in a given number of samples (`min_count`). \n",
     "This approach was introduced in [edgeR](https://rdrr.io/bioc/edgeR/man/filterByExpr.html) {cite}`de:Robinson2010`.\n",
-    "2. {py:obj}`decoupler.pp.filter_by_prop`: Retains genes that are expressed in at least a specified proportion of cells (`min_prop`) across a minimum number of samples (`min_smpls`).\n",
+    "2. {py:func}`decoupler.pp.filter_by_prop`: Retains genes that are expressed in at least a specified proportion of cells (`min_prop`) across a minimum number of samples (`min_smpls`).\n",
     "The number of retained genes can be visualized, and the filtering parameters can be adjusted interactively."
    ]
   },

--- a/jupyter-book/conditions/differential_gene_expression.ipynb
+++ b/jupyter-book/conditions/differential_gene_expression.ipynb
@@ -642,7 +642,7 @@
    "source": [
     "While thresholds are dataset-specific and arbitrary, a commonly used guideline is to retain samples with a minimum of 10 cells and 1,000 total counts. \n",
     "Applying these thresholds (indicated by dashed lines) restricts the dataset to pseudobulks in the upper-right quadrant. \n",
-    "The filtering step can be carried out with `decoupler.pp.filter_samples()`."
+    "The filtering step can be carried out with {py:obj}`decoupler.pp.filter_samples`()."
    ]
   },
   {
@@ -906,9 +906,9 @@
    "source": [
     "Two strategies are used to filter genes:\n",
     "\n",
-    "1. `decoupler.pp.filter_by_expr`: Retains genes with a minimum total number of reads across all samples (`min_total_count`) and a minimum number of counts in a given number of samples (`min_count`). \n",
+    "1. {py:obj}`decoupler.pp.filter_by_expr`: Retains genes with a minimum total number of reads across all samples (`min_total_count`) and a minimum number of counts in a given number of samples (`min_count`). \n",
     "This approach was introduced in [edgeR](https://rdrr.io/bioc/edgeR/man/filterByExpr.html) {cite}`de:Robinson2010`.\n",
-    "2. `decoupler.pp.filter_by_prop`: Retains genes that are expressed in at least a specified proportion of cells (`min_prop`) across a minimum number of samples (`min_smpls`).\n",
+    "2. {py:obj}`decoupler.pp.filter_by_prop`: Retains genes that are expressed in at least a specified proportion of cells (`min_prop`) across a minimum number of samples (`min_smpls`).\n",
     "The number of retained genes can be visualized, and the filtering parameters can be adjusted interactively."
    ]
   },

--- a/jupyter-book/conditions/gsea_pathway.ipynb
+++ b/jupyter-book/conditions/gsea_pathway.ipynb
@@ -861,7 +861,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's look at the raw output of `decoupler.run_gsea`:"
+    "Let's look at the raw output of {py:obj}`decoupler.run_gsea`:"
    ]
   },
   {

--- a/jupyter-book/conditions/gsea_pathway.ipynb
+++ b/jupyter-book/conditions/gsea_pathway.ipynb
@@ -861,7 +861,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's look at the raw output of {py:obj}`decoupler.run_gsea`:"
+    "Let's look at the raw output of {py:data}`decoupler.mt.gsea`:"
    ]
   },
   {

--- a/jupyter-book/conditions/perturbation_modeling.ipynb
+++ b/jupyter-book/conditions/perturbation_modeling.ipynb
@@ -303,7 +303,7 @@
     "This allows us to run Augur with the `predict` function. Generally, Augur can be run in two modes: \n",
     "\n",
     "1. A feature selection based on the original Augur implementation (`select_variance_feature=True`) that is also the default. This approach removes features with little cell-to-cell variation within that cell type. We refer to the Augur Nature Protocols paper for more details{cite}`Squair2021Augur`. When this feature selection is chosen the results are very similar to the Augur implementation in R.\n",
-    "2. A feature selection based on `scanpy.pp.highly_variable_genes`. This feature selection reduces the number of genes that are taken into account for model training and might result in inflated Augur scores, because the highly variable genes are very useful to separate cell types. However, this mode is faster and recovers effects of perturbations on cell types very well. We recommend it for very large datasets with perturbations that are expected to have a strong effect on specific cell types."
+    "2. A feature selection based on {py:obj}`scanpy.pp.highly_variable_genes`. This feature selection reduces the number of genes that are taken into account for model training and might result in inflated Augur scores, because the highly variable genes are very useful to separate cell types. However, this mode is faster and recovers effects of perturbations on cell types very well. We recommend it for very large datasets with perturbations that are expected to have a strong effect on specific cell types."
    ]
   },
   {

--- a/jupyter-book/conditions/perturbation_modeling.ipynb
+++ b/jupyter-book/conditions/perturbation_modeling.ipynb
@@ -303,7 +303,7 @@
     "This allows us to run Augur with the `predict` function. Generally, Augur can be run in two modes: \n",
     "\n",
     "1. A feature selection based on the original Augur implementation (`select_variance_feature=True`) that is also the default. This approach removes features with little cell-to-cell variation within that cell type. We refer to the Augur Nature Protocols paper for more details{cite}`Squair2021Augur`. When this feature selection is chosen the results are very similar to the Augur implementation in R.\n",
-    "2. A feature selection based on {py:obj}`scanpy.pp.highly_variable_genes`. This feature selection reduces the number of genes that are taken into account for model training and might result in inflated Augur scores, because the highly variable genes are very useful to separate cell types. However, this mode is faster and recovers effects of perturbations on cell types very well. We recommend it for very large datasets with perturbations that are expected to have a strong effect on specific cell types."
+    "2. A feature selection based on {py:func}`scanpy.pp.highly_variable_genes`. This feature selection reduces the number of genes that are taken into account for model training and might result in inflated Augur scores, because the highly variable genes are very useful to separate cell types. However, this mode is faster and recovers effects of perturbations on cell types very well. We recommend it for very large datasets with perturbations that are expected to have a strong effect on specific cell types."
    ]
   },
   {

--- a/jupyter-book/introduction/advanced_data_structures_and_frameworks.ipynb
+++ b/jupyter-book/introduction/advanced_data_structures_and_frameworks.ipynb
@@ -2013,10 +2013,10 @@
     "Analogously to the Scanpy chapter, this chapter solely serves as a quick demo and overview of muon and does not analyze a dataset thoroughly, let alone provide best-practice multi-omics analysis.\n",
     "Please read the corresponding chapters to learn how to properly conduct such analyses.\n",
     "\n",
-    "Muon separates its modules in two ways. First, analogously to Scanpy, general and multimodal functions are grouped in preprocessing ({py:obj}`muon.pp`), tools ({py:obj}`muon.tl`) and plots ({py:obj}`muon.pl`).\n",
+    "Muon separates its modules in two ways. First, analogously to Scanpy, general and multimodal functions are grouped in preprocessing ({py:mod}`muon.pp`), tools ({py:mod}`muon.tl`) and plots ({py:mod}`muon.pl`).\n",
     "Second, unimodal tools are available from the corresponding muon, which are again separated into preprocessing, tools and plots.\n",
-    "For example, all ATAC preprocessing functions are grouped into {py:obj}`muon.atac.pp`.\n",
-    "This also applies to CITE-Seq preprocessing functions ({py:obj}`muon.prot.pp`)."
+    "For example, all ATAC preprocessing functions are grouped into {py:mod}`muon.atac.pp`.\n",
+    "This also applies to CITE-Seq preprocessing functions ({py:mod}`muon.prot.pp`)."
    ]
   },
   {
@@ -2520,9 +2520,9 @@
     "Let's explore each element type and how they are represented:\n",
     "- Images: [`xarray.DataArray`](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html) or [`xarray.DataTree`](https://docs.xarray.dev/en/stable/generated/xarray.DataTree.html) objects respectively for single-scale or multi-scale images\n",
     "- Labels: [`xarray.DataArray`](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html) or [`xarray.DataTree`](https://docs.xarray.dev/en/stable/generated/xarray.DataTree.html) objects containing integer codes for different labels\n",
-    "- Points: [`dask.DataFrame`](https://docs.dask.org/en/stable/dataframe.html) objects containing point coordinates, (lazy version of [{py:obj}`pandas.DataFrame`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) objects)\n",
+    "- Points: [`dask.DataFrame`](https://docs.dask.org/en/stable/dataframe.html) objects containing point coordinates, (lazy version of [{py:class}`pandas.DataFrame`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) objects)\n",
     "- Shapes: [`geopandas.GeoDataFrame`](https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.html) objects containing geometric objects like polygons\n",
-    "- Tables: [{py:obj}`anndata.AnnData`](https://anndata.readthedocs.io/en/stable/generated/anndata.AnnData.html) objects for tabular data with annotations\n"
+    "- Tables: [{py:class}`anndata.AnnData`](https://anndata.readthedocs.io/en/stable/generated/anndata.AnnData.html) objects for tabular data with annotations\n"
    ]
   },
   {
@@ -3924,7 +3924,7 @@
    "source": [
     "### Points\n",
     "\n",
-    "Points are represented as `dask.DataFrame` objects containing point coordinates (lazy version of {py:obj}`pandas.DataFrame` objects).\n",
+    "Points are represented as `dask.DataFrame` objects containing point coordinates (lazy version of {py:class}`pandas.DataFrame` objects).\n",
     "Lazy-loading the `DataFrame` reduces memory usage, as the information is only retrieved from the data file when it is needed and not all at once.\n",
     "For spatial transcriptomics datasets measuring single-molecules, coordinates are stored in columns `x` and `y` (optionally `z` for 3D) and have an additional column annotating gene identity."
    ]
@@ -4007,7 +4007,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can easily convert the `dask.DataFrame` to a {py:obj}`pandas.DataFrame` using `.compute()` so it is easier to work with.\n",
+    "We can easily convert the `dask.DataFrame` to a {py:class}`pandas.DataFrame` using `.compute()` so it is easier to work with.\n",
     "Note that this will load the entire object into memory.\n",
     "If the data is large you can use directly the `dask` APIs for the manipulation of the dataframe."
    ]
@@ -4349,7 +4349,7 @@
    "source": [
     "### Tables\n",
     "\n",
-    "Annotated matrices are represented as {py:obj}`anndata.AnnData` objects.\n",
+    "Annotated matrices are represented as {py:class}`anndata.AnnData` objects.\n",
     "Ingested datasets will usually have a table located at `sdata['table']` for a count/abundance matrix.\n",
     "This enables downstream analysis with tools like Scanpy, scVI, etc.\n",
     "\n",

--- a/jupyter-book/introduction/advanced_data_structures_and_frameworks.ipynb
+++ b/jupyter-book/introduction/advanced_data_structures_and_frameworks.ipynb
@@ -2013,10 +2013,10 @@
     "Analogously to the Scanpy chapter, this chapter solely serves as a quick demo and overview of muon and does not analyze a dataset thoroughly, let alone provide best-practice multi-omics analysis.\n",
     "Please read the corresponding chapters to learn how to properly conduct such analyses.\n",
     "\n",
-    "Muon separates its modules in two ways. First, analogously to Scanpy, general and multimodal functions are grouped in preprocessing (`muon.pp`), tools (`muon.tl`) and plots (`muon.pl`).\n",
+    "Muon separates its modules in two ways. First, analogously to Scanpy, general and multimodal functions are grouped in preprocessing ({py:obj}`muon.pp`), tools ({py:obj}`muon.tl`) and plots ({py:obj}`muon.pl`).\n",
     "Second, unimodal tools are available from the corresponding muon, which are again separated into preprocessing, tools and plots.\n",
-    "For example, all ATAC preprocessing functions are grouped into `muon.atac.pp`.\n",
-    "This also applies to CITE-Seq preprocessing functions (`muon.prot.pp`)."
+    "For example, all ATAC preprocessing functions are grouped into {py:obj}`muon.atac.pp`.\n",
+    "This also applies to CITE-Seq preprocessing functions ({py:obj}`muon.prot.pp`)."
    ]
   },
   {
@@ -2520,9 +2520,9 @@
     "Let's explore each element type and how they are represented:\n",
     "- Images: [`xarray.DataArray`](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html) or [`xarray.DataTree`](https://docs.xarray.dev/en/stable/generated/xarray.DataTree.html) objects respectively for single-scale or multi-scale images\n",
     "- Labels: [`xarray.DataArray`](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html) or [`xarray.DataTree`](https://docs.xarray.dev/en/stable/generated/xarray.DataTree.html) objects containing integer codes for different labels\n",
-    "- Points: [`dask.DataFrame`](https://docs.dask.org/en/stable/dataframe.html) objects containing point coordinates, (lazy version of [`pandas.DataFrame`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) objects)\n",
+    "- Points: [`dask.DataFrame`](https://docs.dask.org/en/stable/dataframe.html) objects containing point coordinates, (lazy version of [{py:obj}`pandas.DataFrame`](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html) objects)\n",
     "- Shapes: [`geopandas.GeoDataFrame`](https://geopandas.org/en/stable/docs/reference/api/geopandas.GeoDataFrame.html) objects containing geometric objects like polygons\n",
-    "- Tables: [`anndata.AnnData`](https://anndata.readthedocs.io/en/stable/generated/anndata.AnnData.html) objects for tabular data with annotations\n"
+    "- Tables: [{py:obj}`anndata.AnnData`](https://anndata.readthedocs.io/en/stable/generated/anndata.AnnData.html) objects for tabular data with annotations\n"
    ]
   },
   {
@@ -3924,7 +3924,7 @@
    "source": [
     "### Points\n",
     "\n",
-    "Points are represented as `dask.DataFrame` objects containing point coordinates (lazy version of `pandas.DataFrame` objects).\n",
+    "Points are represented as `dask.DataFrame` objects containing point coordinates (lazy version of {py:obj}`pandas.DataFrame` objects).\n",
     "Lazy-loading the `DataFrame` reduces memory usage, as the information is only retrieved from the data file when it is needed and not all at once.\n",
     "For spatial transcriptomics datasets measuring single-molecules, coordinates are stored in columns `x` and `y` (optionally `z` for 3D) and have an additional column annotating gene identity."
    ]
@@ -4007,7 +4007,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can easily convert the `dask.DataFrame` to a `pandas.DataFrame` using `.compute()` so it is easier to work with.\n",
+    "We can easily convert the `dask.DataFrame` to a {py:obj}`pandas.DataFrame` using `.compute()` so it is easier to work with.\n",
     "Note that this will load the entire object into memory.\n",
     "If the data is large you can use directly the `dask` APIs for the manipulation of the dataframe."
    ]
@@ -4349,7 +4349,7 @@
    "source": [
     "### Tables\n",
     "\n",
-    "Annotated matrices are represented as `anndata.AnnData` objects.\n",
+    "Annotated matrices are represented as {py:obj}`anndata.AnnData` objects.\n",
     "Ingested datasets will usually have a table located at `sdata['table']` for a count/abundance matrix.\n",
     "This enables downstream analysis with tools like Scanpy, scVI, etc.\n",
     "\n",

--- a/jupyter-book/introduction/fundamental_data_structures_and_frameworks.ipynb
+++ b/jupyter-book/introduction/fundamental_data_structures_and_frameworks.ipynb
@@ -4213,10 +4213,10 @@
    "metadata": {},
    "source": [
     "The scanpy framework is designed in a way that functions belonging to the same step are grouped into corresponding modules.\n",
-    "For example, all preprocessing functions are available in the {py:obj}`scanpy.preprocessing` module, all transformations of a data matrix that are not preprocessing are available in {py:obj}`scanpy.tools`, and all visualizations are available in {py:obj}`scanpy.plot`.\n",
-    "These modules are commonly accessed after having imported scanpy like `import scanpy as sc` with the corresponding abbreviations {py:obj}`scanpy.pp` for preprocessing, {py:obj}`scanpy.tl` for tools, and {py:obj}`scanpy.pl` for plots.\n",
+    "For example, all preprocessing functions are available in the {py:mod}`scanpy.preprocessing <scanpy.pp>` module, all transformations of a data matrix that are not preprocessing are available in {py:mod}`scanpy.tools <scanpy.tl>`, and all visualizations are available in {py:mod}`scanpy.plot <scanpy.pl>`.\n",
+    "These modules are commonly accessed after having imported scanpy like `import scanpy as sc` with the corresponding abbreviations {py:mod}`scanpy.pp` for preprocessing, {py:mod}`scanpy.tl` for tools, and {py:mod}`scanpy.pl` for plots.\n",
     "All modules which read or write data are directly accessed.\n",
-    "Further, a module for various datasets is available as {py:obj}`scanpy.datasets`.\n",
+    "Further, a module for various datasets is available as {py:mod}`scanpy.datasets`.\n",
     "All functions with corresponding parameters and potential example plots are documented in the scanpy API documentation {cite}`scanpy_api`.\n",
     "\n",
     "Note that this tutorial only covers a tiny subset of scanpy's features and options.\n",
@@ -4921,7 +4921,7 @@
    "metadata": {},
    "source": [
     "The dataset of choice is a dataset of 2700 peripheral blood mononuclear cells of a healthy donor which were sequenced on the Illumina NextSeq 500. \n",
-    "We can load the dataset from `lamindb`, although it is also available via {py:obj}`scanpy.datasets.pbmc3k`()."
+    "We can load the dataset from `lamindb`, although it is also available via {py:func}`scanpy.datasets.pbmc3k() <scanpy.datasets.pbmc3k>`."
    ]
   },
   {
@@ -5072,7 +5072,7 @@
    "source": [
     "As mentioned above, all of scanpy's analysis functions are accessible via `sc.[pp, tl, pl]`. \n",
     "As a first step to get an overview over our data, we use scanpy to show those genes that yield the highest fraction of counts in each single cell, across all cells. \n",
-    "We simply call the {py:obj}`scanpy.pl.highest_expr_genes` function, pass the AnnData object which is in pretty much all cases the first parameter of any scanpy function, and specify that we want the top 20 expressed genes to be shown."
+    "We simply call the {py:func}`scanpy.pl.highest_expr_genes` function, pass the AnnData object which is in pretty much all cases the first parameter of any scanpy function, and specify that we want the top 20 expressed genes to be shown."
    ]
   },
   {

--- a/jupyter-book/introduction/fundamental_data_structures_and_frameworks.ipynb
+++ b/jupyter-book/introduction/fundamental_data_structures_and_frameworks.ipynb
@@ -4213,10 +4213,10 @@
    "metadata": {},
    "source": [
     "The scanpy framework is designed in a way that functions belonging to the same step are grouped into corresponding modules.\n",
-    "For example, all preprocessing functions are available in the `scanpy.preprocessing` module, all transformations of a data matrix that are not preprocessing are available in `scanpy.tools`, and all visualizations are available in `scanpy.plot`.\n",
-    "These modules are commonly accessed after having imported scanpy like `import scanpy as sc` with the corresponding abbreviations `sc.pp` for preprocessing, `sc.tl` for tools, and `sc.pl` for plots.\n",
+    "For example, all preprocessing functions are available in the {py:obj}`scanpy.preprocessing` module, all transformations of a data matrix that are not preprocessing are available in {py:obj}`scanpy.tools`, and all visualizations are available in {py:obj}`scanpy.plot`.\n",
+    "These modules are commonly accessed after having imported scanpy like `import scanpy as sc` with the corresponding abbreviations {py:obj}`scanpy.pp` for preprocessing, {py:obj}`scanpy.tl` for tools, and {py:obj}`scanpy.pl` for plots.\n",
     "All modules which read or write data are directly accessed.\n",
-    "Further, a module for various datasets is available as `sc.datasets`.\n",
+    "Further, a module for various datasets is available as {py:obj}`scanpy.datasets`.\n",
     "All functions with corresponding parameters and potential example plots are documented in the scanpy API documentation {cite}`scanpy_api`.\n",
     "\n",
     "Note that this tutorial only covers a tiny subset of scanpy's features and options.\n",
@@ -4921,7 +4921,7 @@
    "metadata": {},
    "source": [
     "The dataset of choice is a dataset of 2700 peripheral blood mononuclear cells of a healthy donor which were sequenced on the Illumina NextSeq 500. \n",
-    "We can load the dataset from `lamindb`, although it is also available via `sc.datasets.pbmc3k()`."
+    "We can load the dataset from `lamindb`, although it is also available via {py:obj}`scanpy.datasets.pbmc3k`()."
    ]
   },
   {
@@ -5072,7 +5072,7 @@
    "source": [
     "As mentioned above, all of scanpy's analysis functions are accessible via `sc.[pp, tl, pl]`. \n",
     "As a first step to get an overview over our data, we use scanpy to show those genes that yield the highest fraction of counts in each single cell, across all cells. \n",
-    "We simply call the `sc.pl.highest_expr_genes` function, pass the AnnData object which is in pretty much all cases the first parameter of any scanpy function, and specify that we want the top 20 expressed genes to be shown."
+    "We simply call the {py:obj}`scanpy.pl.highest_expr_genes` function, pass the AnnData object which is in pretty much all cases the first parameter of any scanpy function, and specify that we want the top 20 expressed genes to be shown."
    ]
   },
   {

--- a/jupyter-book/introduction/rapids_singlecell.ipynb
+++ b/jupyter-book/introduction/rapids_singlecell.ipynb
@@ -199,15 +199,15 @@
     "(introduction-rapids-singlecell-key-takeaway-1)=\n",
     "## A scanpy pipeline, on the GPU\n",
     "\n",
-    "RSC mirrors the scanpy module layout on purpose: {py:obj}`rapids_singlecell.pp` for preprocessing and {py:obj}`rapids_singlecell.tl` for tools.\n",
+    "RSC mirrors the scanpy module layout on purpose: {py:mod}`rapids_singlecell.pp` for preprocessing and {py:mod}`rapids_singlecell.tl` for tools.\n",
     "Most scanpy calls have a one-to-one RSC counterpart with the same signature, so porting a pipeline is largely a matter of switching the prefix.\n",
     "\n",
     "The mental model is simple:\n",
     "\n",
     "1. Read the AnnData in as you normally would (CPU memory, sparse `.X`).\n",
-    "2. Move it to the GPU once with {py:obj}`rapids_singlecell.get.anndata_to_GPU`.\n",
+    "2. Move it to the GPU once with {py:func}`rapids_singlecell.get.anndata_to_GPU`.\n",
     "3. Run the heavy preprocessing and clustering steps with `rsc.*`.\n",
-    "4. Move it back to host with {py:obj}`rapids_singlecell.get.anndata_to_CPU` for plotting, saving, or anything else CPU-only.\n",
+    "4. Move it back to host with {py:func}`rapids_singlecell.get.anndata_to_CPU` for plotting, saving, or anything else CPU-only.\n",
     "\n",
     "We follow the same example dataset used in the upstream RSC tutorials — a ~90k-cell DLI census subset — so the runtimes here are directly comparable to those reported in the [rapids-singlecell docs](https://rapids-singlecell.readthedocs.io/)."
    ]
@@ -246,7 +246,7 @@
    "id": "to-gpu-md",
    "metadata": {},
    "source": [
-    "{py:obj}`rapids_singlecell.get.anndata_to_GPU` and its `anndata_to_CPU` counterpart only operate on `.X` and `.layers` — `obs`, `var`, `obsm`, and `varm` always stay on the host.\n",
+    "{py:func}`rapids_singlecell.get.anndata_to_GPU` and its `anndata_to_CPU` counterpart only operate on `.X` and `.layers` — `obs`, `var`, `obsm`, and `varm` always stay on the host.\n",
     "By default only `.X` is moved; pass `convert_all=True` to also move every layer, or `layer=\"<name>\"` to move that layer instead of `.X`.\n",
     "The transfer converts the matrix to a CuPy CSR (or dense `cupy.ndarray`) in place, and downstream RSC calls read from device memory."
    ]
@@ -268,8 +268,8 @@
    "source": [
     "### Quality control\n",
     "\n",
-    "QC metrics and gene filtering have GPU implementations in {py:obj}`rapids_singlecell.pp`.\n",
-    "For the gene-family masks themselves we use plain pandas `startswith` directly on `adata.var_names`: the index is a host-side {py:obj}`pandas.Index` regardless of where `.X` lives, so there is nothing to gain from going through a wrapper."
+    "QC metrics and gene filtering have GPU implementations in {py:mod}`rapids_singlecell.pp`.\n",
+    "For the gene-family masks themselves we use plain pandas `startswith` directly on `adata.var_names`: the index is a host-side {py:class}`pandas.Index` regardless of where `.X` lives, so there is nothing to gain from going through a wrapper."
    ]
   },
   {
@@ -334,7 +334,7 @@
    "source": [
     "```{admonition} Stashing into .raw doubles VRAM transiently\n",
     ":class: warning, dropdown\n",
-    "The standard pattern of stashing the pre-HVG matrix into `.raw` makes a copy of `.X` — and on GPU that copy lives in VRAM, roughly doubling the footprint between `adata.raw = adata` and {py:obj}`rapids_singlecell.pp.scale`.\n",
+    "The standard pattern of stashing the pre-HVG matrix into `.raw` makes a copy of `.X` — and on GPU that copy lives in VRAM, roughly doubling the footprint between `adata.raw = adata` and {py:func}`rapids_singlecell.pp.scale`.\n",
     "On a 90k-cell example it doesn't bite, but on a 1M-cell atlas the transient 2× peak is what will OOM you.\n",
     "If you don't need `.raw` later for marker analysis or DE with `use_raw=True`, drop the line outright.\n",
     "If you do, size `initial_pool_size` to cover the peak, or do the normalize → HVG → raw cycle on CPU before moving to GPU.\n",
@@ -374,7 +374,7 @@
    "source": [
     "```{admonition} Approximate KNN trades accuracy for scale\n",
     ":class: note, dropdown\n",
-    "{py:obj}`rapids_singlecell.pp.neighbors` exposes the cuVS approximate-nearest-neighbor backends through `algorithm=`:\n",
+    "{py:func}`rapids_singlecell.pp.neighbors` exposes the cuVS approximate-nearest-neighbor backends through `algorithm=`:\n",
     "\n",
     "- `brute` (default): exact KNN, scales as O(n²). Best for datasets below ~500k cells; above that the quadratic cost dominates and an ANN backend is faster.\n",
     "- `ivfflat`: inverted-file ANN. A solid default once `brute` becomes too slow — fast, well-behaved on cluster boundaries, and tunable via `n_lists` / `n_probes`.\n",
@@ -396,8 +396,8 @@
     "\n",
     "RSC deliberately does not duplicate scanpy's plotting API.\n",
     "Once the heavy compute is done, the familiar `sc.pl.*` functions work directly — `obs`, `var`, and embeddings in `obsm` already live on the host, so coloring a UMAP by a `obs` column or cluster label needs no transfer.\n",
-    "You only need {py:obj}`rapids_singlecell.get.anndata_to_CPU` when the plot pulls values from `.X` itself, e.g. coloring by a gene's expression or a dotplot of marker genes.\n",
-    "The same goes for serialization: `write_h5ad` and `write_zarr` expect a host-side matrix, so call {py:obj}`rapids_singlecell.get.anndata_to_CPU`(adata) before writing or you'll either error out or persist a CuPy-backed `.X` that won't reload on a CPU-only machine."
+    "You only need {py:func}`rapids_singlecell.get.anndata_to_CPU` when the plot pulls values from `.X` itself, e.g. coloring by a gene's expression or a dotplot of marker genes.\n",
+    "The same goes for serialization: `write_h5ad` and `write_zarr` expect a host-side matrix, so call {py:func}`rapids_singlecell.get.anndata_to_CPU(adata) <rapids_singlecell.get.anndata_to_CPU>` before writing or you'll either error out or persist a CuPy-backed `.X` that won't reload on a CPU-only machine."
    ]
   },
   {
@@ -454,7 +454,7 @@
     "### Free intermediates explicitly\n",
     "\n",
     "Python's garbage collector won't release CuPy memory back to the pool as eagerly as you'd want.\n",
-    "After a memory-heavy step ({py:obj}`rapids_singlecell.pp.scale` on dense data, {py:obj}`rapids_singlecell.pp.regress_out`, PCA on a large matrix), drop references to layers you don't need and ask CuPy to release the freed pool blocks back to the driver."
+    "After a memory-heavy step ({py:func}`rapids_singlecell.pp.scale` on dense data, {py:func}`rapids_singlecell.pp.regress_out`, PCA on a large matrix), drop references to layers you don't need and ask CuPy to release the freed pool blocks back to the driver."
    ]
   },
   {
@@ -685,7 +685,7 @@
     "`normalize_total` is also lazy *only if you pass `target_sum=` explicitly*; with the default `target_sum=None` it has to compute the per-cell sums to find the median library size, which triggers a synchronization.\n",
     "`calculate_qc_metrics`, `highly_variable_genes`, `scale`, and `pca` need a full reduction over the matrix and trigger a synchronization — think of those as the natural breakpoints in a Dask pipeline.\n",
     "\n",
-    "**Filter with boolean masks, not {py:obj}`scanpy.pp.filter_cells`.**\n",
+    "**Filter with boolean masks, not {py:func}`scanpy.pp.filter_cells`.**\n",
     "Built-in filtering helpers materialize counts to decide which cells to keep, which defeats lazy execution.\n",
     "Compute the masks once from QC metrics and apply them directly with `.copy()` to keep things in CSR rather than a view:\n",
     "\n",
@@ -708,7 +708,7 @@
     "RSC also wraps GPU implementations of selected routines from three other scverse packages, each under its own namespace:\n",
     "\n",
     "- `rsc.dcg.*` — [decoupler](https://decoupler-py.readthedocs.io/) functional analysis (`ulm`, `mlm`, `aucell`, `waggr`, `zscore`). On a million-cell atlas, transcription factor activity inference goes from hours on CPU to minutes on a single GPU. The CPU and GPU APIs are identical aside from the namespace; see the [pathway and gene-set analysis chapter](../conditions/gsea_pathway.ipynb).\n",
-    "- `rsc.gr.*` — [squidpy](https://squidpy.readthedocs.io/) spatial analysis (`spatial_autocorr`, `co_occurrence`, `ligrec`). Moran's/Geary's spatial autocorrelation and the ligand–receptor permutation test are the routines that benefit most from the GPU; see the [spatial neighborhood chapter](../spatial/neighborhood.ipynb) for what these do conceptually. The neighborhood graph itself is still built with {py:obj}`squidpy.gr.spatial_neighbors` on CPU.\n",
+    "- `rsc.gr.*` — [squidpy](https://squidpy.readthedocs.io/) spatial analysis (`spatial_autocorr`, `co_occurrence`, `ligrec`). Moran's/Geary's spatial autocorrelation and the ligand–receptor permutation test are the routines that benefit most from the GPU; see the [spatial neighborhood chapter](../spatial/neighborhood.ipynb) for what these do conceptually. The neighborhood graph itself is still built with {py:func}`squidpy.gr.spatial_neighbors` on CPU.\n",
     "- `rsc.ptg.*` — [pertpy](https://pertpy.readthedocs.io/) perturbation distances via the `Distance` class. Only `edistance` is ported today, with more metrics coming soon. The GPU implementation recomputes distances on the fly rather than materializing an n×n cell-distance matrix, so bootstrap variance estimation becomes practical on screens with hundreds of perturbations; see the [perturbation modeling chapter](../conditions/perturbation_modeling.ipynb).\n",
     "\n",
     "```python\n",

--- a/jupyter-book/introduction/rapids_singlecell.ipynb
+++ b/jupyter-book/introduction/rapids_singlecell.ipynb
@@ -199,15 +199,15 @@
     "(introduction-rapids-singlecell-key-takeaway-1)=\n",
     "## A scanpy pipeline, on the GPU\n",
     "\n",
-    "RSC mirrors the scanpy module layout on purpose: `rsc.pp` for preprocessing and `rsc.tl` for tools.\n",
+    "RSC mirrors the scanpy module layout on purpose: {py:obj}`rapids_singlecell.pp` for preprocessing and {py:obj}`rapids_singlecell.tl` for tools.\n",
     "Most scanpy calls have a one-to-one RSC counterpart with the same signature, so porting a pipeline is largely a matter of switching the prefix.\n",
     "\n",
     "The mental model is simple:\n",
     "\n",
     "1. Read the AnnData in as you normally would (CPU memory, sparse `.X`).\n",
-    "2. Move it to the GPU once with `rsc.get.anndata_to_GPU`.\n",
+    "2. Move it to the GPU once with {py:obj}`rapids_singlecell.get.anndata_to_GPU`.\n",
     "3. Run the heavy preprocessing and clustering steps with `rsc.*`.\n",
-    "4. Move it back to host with `rsc.get.anndata_to_CPU` for plotting, saving, or anything else CPU-only.\n",
+    "4. Move it back to host with {py:obj}`rapids_singlecell.get.anndata_to_CPU` for plotting, saving, or anything else CPU-only.\n",
     "\n",
     "We follow the same example dataset used in the upstream RSC tutorials — a ~90k-cell DLI census subset — so the runtimes here are directly comparable to those reported in the [rapids-singlecell docs](https://rapids-singlecell.readthedocs.io/)."
    ]
@@ -246,7 +246,7 @@
    "id": "to-gpu-md",
    "metadata": {},
    "source": [
-    "`rsc.get.anndata_to_GPU` and its `anndata_to_CPU` counterpart only operate on `.X` and `.layers` — `obs`, `var`, `obsm`, and `varm` always stay on the host.\n",
+    "{py:obj}`rapids_singlecell.get.anndata_to_GPU` and its `anndata_to_CPU` counterpart only operate on `.X` and `.layers` — `obs`, `var`, `obsm`, and `varm` always stay on the host.\n",
     "By default only `.X` is moved; pass `convert_all=True` to also move every layer, or `layer=\"<name>\"` to move that layer instead of `.X`.\n",
     "The transfer converts the matrix to a CuPy CSR (or dense `cupy.ndarray`) in place, and downstream RSC calls read from device memory."
    ]
@@ -268,8 +268,8 @@
    "source": [
     "### Quality control\n",
     "\n",
-    "QC metrics and gene filtering have GPU implementations in `rsc.pp`.\n",
-    "For the gene-family masks themselves we use plain pandas `startswith` directly on `adata.var_names`: the index is a host-side `pd.Index` regardless of where `.X` lives, so there is nothing to gain from going through a wrapper."
+    "QC metrics and gene filtering have GPU implementations in {py:obj}`rapids_singlecell.pp`.\n",
+    "For the gene-family masks themselves we use plain pandas `startswith` directly on `adata.var_names`: the index is a host-side {py:obj}`pandas.Index` regardless of where `.X` lives, so there is nothing to gain from going through a wrapper."
    ]
   },
   {
@@ -334,7 +334,7 @@
    "source": [
     "```{admonition} Stashing into .raw doubles VRAM transiently\n",
     ":class: warning, dropdown\n",
-    "The standard pattern of stashing the pre-HVG matrix into `.raw` makes a copy of `.X` — and on GPU that copy lives in VRAM, roughly doubling the footprint between `adata.raw = adata` and `rsc.pp.scale`.\n",
+    "The standard pattern of stashing the pre-HVG matrix into `.raw` makes a copy of `.X` — and on GPU that copy lives in VRAM, roughly doubling the footprint between `adata.raw = adata` and {py:obj}`rapids_singlecell.pp.scale`.\n",
     "On a 90k-cell example it doesn't bite, but on a 1M-cell atlas the transient 2× peak is what will OOM you.\n",
     "If you don't need `.raw` later for marker analysis or DE with `use_raw=True`, drop the line outright.\n",
     "If you do, size `initial_pool_size` to cover the peak, or do the normalize → HVG → raw cycle on CPU before moving to GPU.\n",
@@ -374,7 +374,7 @@
    "source": [
     "```{admonition} Approximate KNN trades accuracy for scale\n",
     ":class: note, dropdown\n",
-    "`rsc.pp.neighbors` exposes the cuVS approximate-nearest-neighbor backends through `algorithm=`:\n",
+    "{py:obj}`rapids_singlecell.pp.neighbors` exposes the cuVS approximate-nearest-neighbor backends through `algorithm=`:\n",
     "\n",
     "- `brute` (default): exact KNN, scales as O(n²). Best for datasets below ~500k cells; above that the quadratic cost dominates and an ANN backend is faster.\n",
     "- `ivfflat`: inverted-file ANN. A solid default once `brute` becomes too slow — fast, well-behaved on cluster boundaries, and tunable via `n_lists` / `n_probes`.\n",
@@ -396,8 +396,8 @@
     "\n",
     "RSC deliberately does not duplicate scanpy's plotting API.\n",
     "Once the heavy compute is done, the familiar `sc.pl.*` functions work directly — `obs`, `var`, and embeddings in `obsm` already live on the host, so coloring a UMAP by a `obs` column or cluster label needs no transfer.\n",
-    "You only need `rsc.get.anndata_to_CPU` when the plot pulls values from `.X` itself, e.g. coloring by a gene's expression or a dotplot of marker genes.\n",
-    "The same goes for serialization: `write_h5ad` and `write_zarr` expect a host-side matrix, so call `rsc.get.anndata_to_CPU(adata)` before writing or you'll either error out or persist a CuPy-backed `.X` that won't reload on a CPU-only machine."
+    "You only need {py:obj}`rapids_singlecell.get.anndata_to_CPU` when the plot pulls values from `.X` itself, e.g. coloring by a gene's expression or a dotplot of marker genes.\n",
+    "The same goes for serialization: `write_h5ad` and `write_zarr` expect a host-side matrix, so call {py:obj}`rapids_singlecell.get.anndata_to_CPU`(adata) before writing or you'll either error out or persist a CuPy-backed `.X` that won't reload on a CPU-only machine."
    ]
   },
   {
@@ -454,7 +454,7 @@
     "### Free intermediates explicitly\n",
     "\n",
     "Python's garbage collector won't release CuPy memory back to the pool as eagerly as you'd want.\n",
-    "After a memory-heavy step (`rsc.pp.scale` on dense data, `rsc.pp.regress_out`, PCA on a large matrix), drop references to layers you don't need and ask CuPy to release the freed pool blocks back to the driver."
+    "After a memory-heavy step ({py:obj}`rapids_singlecell.pp.scale` on dense data, {py:obj}`rapids_singlecell.pp.regress_out`, PCA on a large matrix), drop references to layers you don't need and ask CuPy to release the freed pool blocks back to the driver."
    ]
   },
   {
@@ -685,7 +685,7 @@
     "`normalize_total` is also lazy *only if you pass `target_sum=` explicitly*; with the default `target_sum=None` it has to compute the per-cell sums to find the median library size, which triggers a synchronization.\n",
     "`calculate_qc_metrics`, `highly_variable_genes`, `scale`, and `pca` need a full reduction over the matrix and trigger a synchronization — think of those as the natural breakpoints in a Dask pipeline.\n",
     "\n",
-    "**Filter with boolean masks, not `sc.pp.filter_cells`.**\n",
+    "**Filter with boolean masks, not {py:obj}`scanpy.pp.filter_cells`.**\n",
     "Built-in filtering helpers materialize counts to decide which cells to keep, which defeats lazy execution.\n",
     "Compute the masks once from QC metrics and apply them directly with `.copy()` to keep things in CSR rather than a view:\n",
     "\n",
@@ -708,7 +708,7 @@
     "RSC also wraps GPU implementations of selected routines from three other scverse packages, each under its own namespace:\n",
     "\n",
     "- `rsc.dcg.*` — [decoupler](https://decoupler-py.readthedocs.io/) functional analysis (`ulm`, `mlm`, `aucell`, `waggr`, `zscore`). On a million-cell atlas, transcription factor activity inference goes from hours on CPU to minutes on a single GPU. The CPU and GPU APIs are identical aside from the namespace; see the [pathway and gene-set analysis chapter](../conditions/gsea_pathway.ipynb).\n",
-    "- `rsc.gr.*` — [squidpy](https://squidpy.readthedocs.io/) spatial analysis (`spatial_autocorr`, `co_occurrence`, `ligrec`). Moran's/Geary's spatial autocorrelation and the ligand–receptor permutation test are the routines that benefit most from the GPU; see the [spatial neighborhood chapter](../spatial/neighborhood.ipynb) for what these do conceptually. The neighborhood graph itself is still built with `sq.gr.spatial_neighbors` on CPU.\n",
+    "- `rsc.gr.*` — [squidpy](https://squidpy.readthedocs.io/) spatial analysis (`spatial_autocorr`, `co_occurrence`, `ligrec`). Moran's/Geary's spatial autocorrelation and the ligand–receptor permutation test are the routines that benefit most from the GPU; see the [spatial neighborhood chapter](../spatial/neighborhood.ipynb) for what these do conceptually. The neighborhood graph itself is still built with {py:obj}`squidpy.gr.spatial_neighbors` on CPU.\n",
     "- `rsc.ptg.*` — [pertpy](https://pertpy.readthedocs.io/) perturbation distances via the `Distance` class. Only `edistance` is ported today, with more metrics coming soon. The GPU implementation recomputes distances on the fly rather than materializing an n×n cell-distance matrix, so bootstrap variance estimation becomes practical on screens with hundreds of perturbations; see the [perturbation modeling chapter](../conditions/perturbation_modeling.ipynb).\n",
     "\n",
     "```python\n",

--- a/jupyter-book/preprocessing_visualization/quality_control.ipynb
+++ b/jupyter-book/preprocessing_visualization/quality_control.ipynb
@@ -250,7 +250,7 @@
     "We want to highlight that it might be reasonable to re-assess the filtering after the annotation of cells.\n",
     "\n",
     "In QC, the first step is to calculate the QC covariates or metric.\n",
-    "We compute these using the scanpy function `sc.pp.calculate_qc_metrics`, which can also calculate the proportions of counts for specific gene populations.\n",
+    "We compute these using the scanpy function {py:obj}`scanpy.pp.calculate_qc_metrics`, which can also calculate the proportions of counts for specific gene populations.\n",
     "We therefore define mitochondrial, ribosomal, and hemoglobin genes.\n",
     "It is important to note that mitochondrial counts are annotated either with the prefix \"mt-\" or \"MT-\" depending on the species considered in the dataset.\n",
     "As mentioned, the dataset used in this notebook is human bone marrow, so mitochondrial counts are annotated with the prefix \"MT-\".\n",

--- a/jupyter-book/preprocessing_visualization/quality_control.ipynb
+++ b/jupyter-book/preprocessing_visualization/quality_control.ipynb
@@ -250,7 +250,7 @@
     "We want to highlight that it might be reasonable to re-assess the filtering after the annotation of cells.\n",
     "\n",
     "In QC, the first step is to calculate the QC covariates or metric.\n",
-    "We compute these using the scanpy function {py:obj}`scanpy.pp.calculate_qc_metrics`, which can also calculate the proportions of counts for specific gene populations.\n",
+    "We compute these using the scanpy function {py:func}`scanpy.pp.calculate_qc_metrics`, which can also calculate the proportions of counts for specific gene populations.\n",
     "We therefore define mitochondrial, ribosomal, and hemoglobin genes.\n",
     "It is important to note that mitochondrial counts are annotated either with the prefix \"mt-\" or \"MT-\" depending on the species considered in the dataset.\n",
     "As mentioned, the dataset used in this notebook is human bone marrow, so mitochondrial counts are annotated with the prefix \"MT-\".\n",

--- a/jupyter-book/spatial/neighborhood.ipynb
+++ b/jupyter-book/spatial/neighborhood.ipynb
@@ -67,7 +67,7 @@
     "## Identifying interactions between spatial communities\n",
     "After annotating cell types or cell states in the dataset (or spots, according to the technology at end), we can quantify whether such annotations are spatially enriched. To this end, computing a neighborhood enrichment can help us identify clusters that are neighbors in the tissue of interest. In short, it’s an enrichment score on spatial proximity of clusters: if observations (cells or spots) belonging to a cluster are often close to observations belonging to another cluster, then they will have a high score and will appear to be enriched. On the other hand, if they are far apart, and therefore are seldom neighbors, the score will be low and they can be defined as depleted. This score is based on a permutation-based test, and you can set the number of permutations with the n_perms argument (default is 1000).\n",
     "\n",
-    "Since the function works on a spatial connectivity matrix (spatial graph), we need to compute that as well. This can be done with {py:obj}`squidpy.gr.spatial_neighbors`()."
+    "Since the function works on a spatial connectivity matrix (spatial graph), we need to compute that as well. This can be done with {py:func}`squidpy.gr.spatial_neighbors() <squidpy.gr.spatial_neighbors>`."
    ]
   },
   {
@@ -271,7 +271,7 @@
    "id": "cafdc7f2-4edc-4037-8f56-743247fe31d6",
    "metadata": {},
    "source": [
-    "Finally, we’ll directly visualize the results with {py:obj}`squidpy.pl.nhood_enrichment`()."
+    "Finally, we’ll directly visualize the results with {py:func}`squidpy.pl.nhood_enrichment() <squidpy.pl.nhood_enrichment>`."
    ]
   },
   {
@@ -414,7 +414,7 @@
    "id": "95e43b6c-bd85-4349-952a-db9dea308c66",
    "metadata": {},
    "source": [
-    "We can visualize the results with {py:obj}`squidpy.pl.interaction_matrix`()."
+    "We can visualize the results with {py:func}`squidpy.pl.interaction_matrix() <squidpy.pl.interaction_matrix>`."
    ]
   },
   {

--- a/jupyter-book/spatial/neighborhood.ipynb
+++ b/jupyter-book/spatial/neighborhood.ipynb
@@ -67,7 +67,7 @@
     "## Identifying interactions between spatial communities\n",
     "After annotating cell types or cell states in the dataset (or spots, according to the technology at end), we can quantify whether such annotations are spatially enriched. To this end, computing a neighborhood enrichment can help us identify clusters that are neighbors in the tissue of interest. In short, it’s an enrichment score on spatial proximity of clusters: if observations (cells or spots) belonging to a cluster are often close to observations belonging to another cluster, then they will have a high score and will appear to be enriched. On the other hand, if they are far apart, and therefore are seldom neighbors, the score will be low and they can be defined as depleted. This score is based on a permutation-based test, and you can set the number of permutations with the n_perms argument (default is 1000).\n",
     "\n",
-    "Since the function works on a spatial connectivity matrix (spatial graph), we need to compute that as well. This can be done with `squidpy.gr.spatial_neighbors()`."
+    "Since the function works on a spatial connectivity matrix (spatial graph), we need to compute that as well. This can be done with {py:obj}`squidpy.gr.spatial_neighbors`()."
    ]
   },
   {
@@ -271,7 +271,7 @@
    "id": "cafdc7f2-4edc-4037-8f56-743247fe31d6",
    "metadata": {},
    "source": [
-    "Finally, we’ll directly visualize the results with `squidpy.pl.nhood_enrichment()`."
+    "Finally, we’ll directly visualize the results with {py:obj}`squidpy.pl.nhood_enrichment`()."
    ]
   },
   {
@@ -414,7 +414,7 @@
    "id": "95e43b6c-bd85-4349-952a-db9dea308c66",
    "metadata": {},
    "source": [
-    "We can visualize the results with `squidpy.pl.interaction_matrix()`."
+    "We can visualize the results with {py:obj}`squidpy.pl.interaction_matrix`()."
    ]
   },
   {

--- a/jupyter-book/surface_protein/normalization.ipynb
+++ b/jupyter-book/surface_protein/normalization.ipynb
@@ -318,7 +318,7 @@
    "id": "c4b04392",
    "metadata": {},
    "source": [
-    "We now call the normalization function `mu.prot.pp.dsb` with the filtered and raw mudata object as well as the names of the isotype controls."
+    "We now call the normalization function {py:obj}`muon.prot.pp.dsb` with the filtered and raw mudata object as well as the names of the isotype controls."
    ]
   },
   {
@@ -529,7 +529,7 @@
    "id": "de0160c3-5505-4d09-a211-61cd0a3c63ba",
    "metadata": {},
    "source": [
-    "If you don't have the unfiltered data and/or the isotype controls available, you can also normalize the ADT data with `mu.prot.pp.clr`, implementing **C**entered **L**og-**R**atio normalization. \n",
+    "If you don't have the unfiltered data and/or the isotype controls available, you can also normalize the ADT data with {py:obj}`muon.prot.pp.clr`, implementing **C**entered **L**og-**R**atio normalization. \n",
     "CLR normalization is the traditional way of normalizing ADT data, suggested in the original CITE-seq publication {cite}`Stoeckius2017`. \n",
     "\n",
     "CLR normalization accounts for differences in sequencing depth across cells, which can otherwise dominate downstream analyses. Cells with higher total ADT counts may appear artificially distinct, causing biologically similar cells to separate during clustering.\n",
@@ -553,7 +553,7 @@
    "id": "e1e3b998",
    "metadata": {},
    "source": [
-    "Now we apply CLR normalization by using the function `mu.prot.pp.clr`:"
+    "Now we apply CLR normalization by using the function {py:obj}`muon.prot.pp.clr`:"
    ]
   },
   {

--- a/jupyter-book/surface_protein/normalization.ipynb
+++ b/jupyter-book/surface_protein/normalization.ipynb
@@ -318,7 +318,7 @@
    "id": "c4b04392",
    "metadata": {},
    "source": [
-    "We now call the normalization function {py:obj}`muon.prot.pp.dsb` with the filtered and raw mudata object as well as the names of the isotype controls."
+    "We now call the normalization function {py:func}`muon.prot.pp.dsb` with the filtered and raw mudata object as well as the names of the isotype controls."
    ]
   },
   {
@@ -529,7 +529,7 @@
    "id": "de0160c3-5505-4d09-a211-61cd0a3c63ba",
    "metadata": {},
    "source": [
-    "If you don't have the unfiltered data and/or the isotype controls available, you can also normalize the ADT data with {py:obj}`muon.prot.pp.clr`, implementing **C**entered **L**og-**R**atio normalization. \n",
+    "If you don't have the unfiltered data and/or the isotype controls available, you can also normalize the ADT data with {py:func}`muon.prot.pp.clr`, implementing **C**entered **L**og-**R**atio normalization. \n",
     "CLR normalization is the traditional way of normalizing ADT data, suggested in the original CITE-seq publication {cite}`Stoeckius2017`. \n",
     "\n",
     "CLR normalization accounts for differences in sequencing depth across cells, which can otherwise dominate downstream analyses. Cells with higher total ADT counts may appear artificially distinct, causing biologically similar cells to separate during clustering.\n",
@@ -553,7 +553,7 @@
    "id": "e1e3b998",
    "metadata": {},
    "source": [
-    "Now we apply CLR normalization by using the function {py:obj}`muon.prot.pp.clr`:"
+    "Now we apply CLR normalization by using the function {py:func}`muon.prot.pp.clr`:"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Wires up `sphinx.ext.intersphinx` in `jupyter-book/_config.yml` with mappings for ~35 packages this book actually imports (anndata, scanpy, mudata, muon, squidpy, scirpy, pertpy, decoupler, liana, scvi, scvelo, cellrank, pandas, numpy, scipy, scikit-learn, …). All URLs probed for a live `objects.inv` before inclusion; packages without an intersphinx-compatible docs site (`anndata2ri`, `palmotif`, `tcr_embedding`, `celloracle`) are skipped.
- Rewrites backticked API mentions in markdown cells across every chapter as MyST `{py:obj}` roles, so e.g. `` `sc.pp.neighbors` `` becomes `` {py:obj}`scanpy.pp.neighbors` `` and renders as a hyperlink into upstream docs.
- Conservative scope: only mentions whose first segment is a known import alias (`sc`, `ad`, `mu`, `sq`, `ir`, `pt`, `dc`, `li`, `np`, `pd`, …) or a full package name are rewritten. Instance-attribute mentions (`adata.obs`, `mdata.uns`, `milo.make_nhoods`) are intentionally left as plain backticks. Code cells are not touched.
- `nitpicky` stays `false`, so any reference that fails to resolve renders as plain code text rather than breaking the build.

