### PR TITLE
Remove inline TODO notes from the text (#249)

### DIFF
--- a/jupyter-book/air_repertoire/multimodal_integration.ipynb
+++ b/jupyter-book/air_repertoire/multimodal_integration.ipynb
@@ -477,17 +477,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 12,
-   "id": "4327b6b8",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO: remove clonotype definition once this is handled by clonotype chapter\n",
-    "# ir.pl.alpha_diversity(adata_tc, groupby=\"full_clustering\", target_col=\"clone_id\", figsize=[8, 4])"
-   ]
-  },
-  {
    "attachments": {},
    "cell_type": "markdown",
    "id": "77e69f62",
@@ -501,7 +490,7 @@
     "- **Clonotype Network**: To increase the amount of cells to track, we can use networks of clonotypes with similar AIR sequence instead of clonotypes. While these cells are not ancestrally related, they are likely to share the same specificity.\n",
     "- **Disease Specificity**: We previously queried databases, to detect epitope specific AIRs. We can now use this annotation, to investigate, how B- or T-cells reactive to selected diseases differ from other cells. Here, we must be cautious, since the dataset query provides us only with positive annotation: by same or similar AIR, we identify cells specific to a certain epitope. However, a missing pair of AIR and epitope in a database is not indicative of this binding being impossible.\n",
     "\n",
-    "As for the previous subsection, the selected condition and analysis are highly depended on your research question. In the previous notebooks, we annotated these conditions in ```adata.obs```. Since they can, hence, be applied for DEG analysis in the same fashion, we will only showcase DEG by #todo when the rest is unified."
+    "As for the previous subsection, the selected condition and analysis are highly depended on your research question. In the previous notebooks, we annotated these conditions in ```adata.obs```. Since they can, hence, be applied for DEG analysis in the same fashion, we will only showcase DEG below."
    ]
   },
   {
@@ -531,19 +520,8 @@
     }
    ],
    "source": [
-    "# todo change once load clonotype annotated data\n",
     "sc.tl.rank_genes_groups(adata_tc, groupby=\"elevated_IFNG\")\n",
     "sc.pl.rank_genes_groups(adata_tc, groupby=\"elevated_IFNG\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "9b7ddeba",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# TODO adapt to disease specific cells => Covid B cells against rest"
    ]
   },
   {
@@ -1432,7 +1410,7 @@
    "id": "0ee3486c",
    "metadata": {},
    "source": [
-    "The AnnData object requires a clonotype assignment (see chapter {ref}`air:sequence`). Since mvTCR uses both chains of the primary receptor, we will use this information for defining the clonotype as well. # todo => use the one provided"
+    "The AnnData object requires a clonotype assignment (see chapter {ref}`air:sequence`). Since mvTCR uses both chains of the primary receptor, we will use this information for defining the clonotype as well."
    ]
   },
   {
@@ -1460,7 +1438,6 @@
     }
    ],
    "source": [
-    "# todo delete once data is unified\n",
     "ir.tl.define_clonotypes(\n",
     "    adata_mvtcr, key_added=\"clonotype\", receptor_arms=\"all\", dual_ir=\"primary_only\"\n",
     ")"

--- a/jupyter-book/air_repertoire/specificity.ipynb
+++ b/jupyter-book/air_repertoire/specificity.ipynb
@@ -100,7 +100,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# TODO final decision sampling: prosponed until remaining chapters are fixed\n",
     "adata_tcr = adata_tcr[adata_tcr.obs[\"patient_id\"].isin([\"CV0902\", \"AP6\"])].copy()"
    ]
   },
@@ -607,7 +606,7 @@
    "id": "5210aa0a",
    "metadata": {},
    "source": [
-    "We observe several matches towards different diseases. These annotations must be viewed carefully, since they depend on the abundance of the disease in the databases, wrong annotation in the databases, false matches due to incomplete information, and possible MHC restrictions of epitopes. However, from the great abundance of disease-specific TCRs, we could deduct, that one patient has a latent infection towards the Cytomegalovirus (CMV) and Epstein–Barr virus (EBV), which are common in population. However, the third most common disease association is toward the less frequent HIV-1. # todo: might change when different donors are chosen"
+    "We observe several matches towards different diseases. These annotations must be viewed carefully, since they depend on the abundance of the disease in the databases, wrong annotation in the databases, false matches due to incomplete information, and possible MHC restrictions of epitopes. However, from the great abundance of disease-specific TCRs, we could deduct, that one patient has a latent infection towards the Cytomegalovirus (CMV) and Epstein–Barr virus (EBV), which are common in population. However, the third most common disease association is toward the less frequent HIV-1."
    ]
   },
   {
@@ -1145,7 +1144,7 @@
     "df_tcrdist[\"v_a_gene\"] = df_tcrdist[\"v_a_gene\"].astype(str) + \"*01\"\n",
     "df_tcrdist[\"v_b_gene\"] = df_tcrdist[\"v_b_gene\"].astype(str) + \"*01\"\n",
     "\n",
-    "df_tcrdist[\"count\"] = 1  # todo\n",
+    "df_tcrdist[\"count\"] = 1\n",
     "\n",
     "df_tcrdist[\"index\"] = df_tcrdist.index\n",
     "\n",
@@ -2487,14 +2486,6 @@
     "import numpy as np\n",
     "\n",
     "np.sum(df_tcr_ergo[\"Score\"] >= 0.9)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6130d445",
-   "metadata": {},
-   "source": [
-    "TODO: Interpretation once donors fixed."
    ]
   },
   {

--- a/jupyter-book/multimodal_integration/paired_integration.ipynb
+++ b/jupyter-book/multimodal_integration/paired_integration.ipynb
@@ -580,7 +580,6 @@
    "outputs": [],
    "source": [
     "%%R\n",
-    "# TODO need to change after we have the preprocessed data, for now RNA is not batch-corrected\n",
     "DefaultAssay(cite) <- \"RNA\"\n",
     "VariableFeatures(cite) <- rownames(cite)\n",
     "cite <- ScaleData(cite, verbose=FALSE)\n",


### PR DESCRIPTION
Closes #249.

A reader pointed out that author `TODO` notes are scattered through the book text — some of them rendered into the published HTML, which looks confusing and is a poor way to track tasks.

This sweeps every TODO out of the chapter source (11 across 3 notebooks):

**`air_repertoire/multimodal_integration.ipynb`**
- Deleted the comment-only cell holding `# TODO: remove clonotype definition …` plus its commented-out `ir.pl.alpha_diversity` call (dead code, never executed).
- Deleted the comment-only cell `# TODO adapt to disease specific cells => Covid B cells against rest`.
- Stripped `# todo change once load clonotype annotated data` and `# todo delete once data is unified`, keeping the functional code.
- Reworded the rendered sentence `… we will only showcase DEG by #todo when the rest is unified.` → `… we will only showcase DEG below.`
- Trimmed the rendered `… defining the clonotype as well. # todo => use the one provided` → `… defining the clonotype as well.`

**`air_repertoire/specificity.ipynb`**
- Stripped `# TODO final decision sampling: prosponed until remaining chapters are fixed`, keeping the patient subsampling.
- Trimmed the rendered `… the less frequent HIV-1. # todo: might change when different donors are chosen` → `… the less frequent HIV-1.`
- Dropped the trailing `# todo` on `df_tcrdist["count"] = 1`.
- Deleted the markdown cell that contained only `TODO: Interpretation once donors fixed.`

**`multimodal_integration/paired_integration.ipynb`**
- Stripped `# TODO need to change after we have the preprocessed data, …`, keeping the R code.

No executed code paths change — only comments, two placeholder-only cells, and three prose sentences. `grep -i todo` over the chapter source is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)