### PR TITLE
Fix invisible MuData/AnnData object summaries (#435)

### DIFF
--- a/changelog.d/444.fixed.md
+++ b/changelog.d/444.fixed.md
@@ -1,0 +1,1 @@
+Fix invisible MuData/AnnData object summaries caused by a quiz CSS rule leaking `--pst-color-text-base: transparent` to all cell outputs. ([#444](https://github.com/theislab/single-cell-best-practices/pull/444)) <sub>@Zethson</sub>

--- a/jupyter-book/air_repertoire/ir_profiling.ipynb
+++ b/jupyter-book/air_repertoire/ir_profiling.ipynb
@@ -3226,9 +3226,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -3307,9 +3304,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -3388,9 +3382,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",

--- a/jupyter-book/air_repertoire/multimodal_integration.ipynb
+++ b/jupyter-book/air_repertoire/multimodal_integration.ipynb
@@ -2399,9 +2399,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2480,9 +2477,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2561,9 +2555,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",

--- a/jupyter-book/air_repertoire/specificity.ipynb
+++ b/jupyter-book/air_repertoire/specificity.ipynb
@@ -3218,9 +3218,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -3299,9 +3296,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -3380,9 +3374,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",

--- a/jupyter-book/cellular_structure/integration.ipynb
+++ b/jupyter-book/cellular_structure/integration.ipynb
@@ -3867,9 +3867,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -3948,9 +3945,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -4029,9 +4023,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",

--- a/jupyter-book/chromatin_accessibility/gene_regulatory_networks_atac.ipynb
+++ b/jupyter-book/chromatin_accessibility/gene_regulatory_networks_atac.ipynb
@@ -2700,9 +2700,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2781,9 +2778,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2862,9 +2856,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2943,9 +2934,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q4 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -3052,9 +3040,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",

--- a/jupyter-book/conditions/compositional.ipynb
+++ b/jupyter-book/conditions/compositional.ipynb
@@ -4698,9 +4698,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -4779,9 +4776,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -4860,9 +4854,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",

--- a/jupyter-book/conditions/differential_gene_expression.ipynb
+++ b/jupyter-book/conditions/differential_gene_expression.ipynb
@@ -2310,9 +2310,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 290px;\n",
@@ -2391,9 +2388,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 290px;\n",
@@ -2472,9 +2466,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 290px;\n",
@@ -2580,9 +2571,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",
@@ -2653,9 +2641,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",
@@ -2726,9 +2711,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",

--- a/jupyter-book/conditions/gsea_pathway.ipynb
+++ b/jupyter-book/conditions/gsea_pathway.ipynb
@@ -1902,9 +1902,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -1983,9 +1980,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2064,9 +2058,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2145,9 +2136,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q4 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2226,9 +2214,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q5 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",

--- a/jupyter-book/conditions/perturbation_modeling.ipynb
+++ b/jupyter-book/conditions/perturbation_modeling.ipynb
@@ -2618,9 +2618,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2699,9 +2696,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2780,9 +2774,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",

--- a/jupyter-book/introduction/advanced_data_structures_and_frameworks.ipynb
+++ b/jupyter-book/introduction/advanced_data_structures_and_frameworks.ipynb
@@ -4680,9 +4680,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -4761,9 +4758,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -4842,9 +4836,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -4962,9 +4953,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",
@@ -5035,9 +5023,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",
@@ -5108,9 +5093,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",

--- a/jupyter-book/introduction/fundamental_data_structures_and_frameworks.ipynb
+++ b/jupyter-book/introduction/fundamental_data_structures_and_frameworks.ipynb
@@ -5263,9 +5263,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -5344,9 +5341,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -5425,9 +5419,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -5545,9 +5536,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",
@@ -5618,9 +5606,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",
@@ -5691,9 +5676,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",

--- a/jupyter-book/introduction/rapids_singlecell.ipynb
+++ b/jupyter-book/introduction/rapids_singlecell.ipynb
@@ -765,9 +765,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",
@@ -838,9 +835,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",
@@ -911,9 +905,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 290px;\n",

--- a/jupyter-book/introduction/scrna_seq.ipynb
+++ b/jupyter-book/introduction/scrna_seq.ipynb
@@ -529,9 +529,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q5 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -610,9 +607,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q6 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -691,9 +685,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q7 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -772,9 +763,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q8 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -898,9 +886,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",
@@ -971,9 +956,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",
@@ -1044,9 +1026,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",
@@ -1117,9 +1096,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",

--- a/jupyter-book/mechanisms/cell_cell_communication.ipynb
+++ b/jupyter-book/mechanisms/cell_cell_communication.ipynb
@@ -2141,9 +2141,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2222,9 +2219,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2303,9 +2297,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2384,9 +2375,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q4 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",

--- a/jupyter-book/mechanisms/gene_regulatory_networks.ipynb
+++ b/jupyter-book/mechanisms/gene_regulatory_networks.ipynb
@@ -1942,9 +1942,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2023,9 +2020,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q2 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -2104,9 +2098,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q3 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",

--- a/jupyter-book/src/lib.py
+++ b/jupyter-book/src/lib.py
@@ -50,9 +50,6 @@ def multiple_choice_question(
 
     html_code = f"""
     <style>
-        .output.text_html {{
-            --pst-color-text-base: transparent !important;
-        }}
         .mcq-box {{
             border: none !important;
             box-shadow: none !important;
@@ -122,9 +119,6 @@ def flip_card(
     """
     html_code = f"""
     <style>
-        .output.text_html {{
-            --pst-color-text-base: transparent !important;
-        }}
         .flip-card-{question_id} {{
             background-color: transparent;
             width: 290px;

--- a/jupyter-book/template/template.ipynb
+++ b/jupyter-book/template/template.ipynb
@@ -300,9 +300,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .flip-card-q1 {\n",
        "            background-color: transparent;\n",
        "            width: 350px;\n",
@@ -381,9 +378,6 @@
       "text/html": [
        "\n",
        "    <style>\n",
-       "        .output.text_html {\n",
-       "            --pst-color-text-base: transparent !important;\n",
-       "        }\n",
        "        .mcq-box {\n",
        "            border: none !important;\n",
        "            box-shadow: none !important;\n",


### PR DESCRIPTION
Fixes #435.

## Problem

The MuData (and AnnData) object summaries render as invisible text in **all chapters** — the text is there (you can select and copy it) but it's transparent.

The cause is the quiz helpers `flip_card()` and `multiple_choice_question()` in `jupyter-book/src/lib.py`, which inject a global CSS rule into each chapter:

```css
.output.text_html { --pst-color-text-base: transparent !important; }
```

Jupyter Book renders a whole chapter into a single HTML page, so this `<style>` is not scoped to the quiz — it applies to **every** cell output on the page. MuData/AnnData reprs render as `<div class="output text_html">`, so `--pst-color-text-base` (the pydata-sphinx-theme text color variable) is forced to `transparent !important`, making the summaries invisible. Since every chapter embeds a quiz from this template, the bug shows up everywhere.

## Fix

- Removed the offending rule from both helpers in `src/lib.py` so future rebuilds are clean. The quiz boxes are unaffected — they already set their own text colors explicitly (`color: white` / `color: {text_color}`).
- Scrubbed the rule out of the already-baked notebook outputs (66 occurrences across 16 notebooks) so the fix takes effect **without rerunning** the notebooks. These are pure deletions; nbformat is preserved.

Benign uses of `--pst-color-text-base` (e.g. the SpatialData repr reading it with a proper `var(..., fallback)`) are left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)