### PR TITLE
Fix inline code and cell output formatting

### DIFF
--- a/jupyter-book/_static/custom.css
+++ b/jupyter-book/_static/custom.css
@@ -1,14 +1,12 @@
 /*
- * Styling the MyST book theme does not provide out of the box, kept close to the look
- * of the previous Sphinx build of this book.
+ * Styling the MyST book theme does not provide out of the box, kept close to the look of the previous Sphinx build of this book.
  */
 
 /*
  * In-text citations.
  *
- * The theme renders a parenthetical citation group as a bare span, so "{cite:p}`a,b`"
- * comes out undelimited as "Doe et al., 2020; Roe et al., 2021". Put the brackets of the
- * old build back around it.
+ * The theme renders a parenthetical citation group as a bare span, so "{cite:p}`a,b`" comes out undelimited as "Doe et al., 2020; Roe et al., 2021".
+ * Put the brackets of the old build back around it.
  */
 .cite-group.parenthetical::before {
   content: "[";
@@ -18,33 +16,48 @@
   content: "]";
 }
 
-/* Inline code: set it off from the surrounding prose the way the old build did. */
-:not(pre) > code {
+/*
+ * Inline code: set it off from the surrounding prose the way the old build did.
+ *
+ * Both rules are wrapped in ":where()" so that they carry no specificity and the exceptions below win on order alone.
+ * Without it the dark variant, a class and therefore more specific than the exceptions, puts the box back on everything that opts out.
+ */
+:where(:not(pre) > code) {
   padding: 0.15em 0.35em;
   border: 1px solid rgb(231 229 228);
   border-radius: 0.25rem;
   background-color: rgb(250 250 249);
 }
 
-.dark :not(pre) > code {
+:where(.dark :not(pre) > code) {
   border-color: rgb(68 64 60);
   background-color: rgb(41 37 36);
 }
 
-/* Headings, links and admonition titles keep their own styling. */
+/*
+ * Headings, links and admonition titles keep their own styling, and a cell output is code already, so its grey backdrop below is all it gets.
+ *
+ * Cards are excluded from the link rule: a key takeaway card is a link around a paragraph rather than a link inside one, so its inline code reads as prose and is boxed like the rest of the text.
+ * The theme colours code inside a link like the link, which for a card is the card text, so the prose colour is put back as well.
+ */
 h1 code,
 h2 code,
 h3 code,
 h4 code,
 h5 code,
 h6 code,
-a code,
+a:not(.myst-card) code,
 summary code,
 .myst-admonition-header code,
-.myst-dropdown-header code {
+.myst-dropdown-header code,
+[data-name="outputs-container"] code {
   padding: 0;
   border: 0;
   background-color: transparent;
+}
+
+.myst-card code {
+  color: var(--tw-prose-code);
 }
 
 /* Code cells and their text output: grey backdrop, as in the old build. */
@@ -65,5 +78,24 @@ summary code,
 
 .dark [data-name="safe-output-stream"],
 .dark [data-name="safe-output-text"] {
+  background-color: rgb(41 37 36);
+}
+
+/*
+ * An output that ships HTML, such as a MuData object description or a rich console log, is not one of the output types the theme renders itself, so it goes through the notebook renderer and misses the backdrop above.
+ * Only a container holding a bare preformatted block is picked up, which is what those descriptions and logs are; tables, widgets and figures keep the layout they bring along.
+ * The margin the notebook renderer puts around the block is dropped so that it lines up with the other outputs.
+ */
+[data-name="outputs-container"] .jp-RenderedHTML:has(> pre) {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.25rem;
+  background-color: rgb(245 245 244);
+}
+
+[data-name="outputs-container"] .jp-RenderedHTML > pre {
+  margin: 0;
+}
+
+.dark [data-name="outputs-container"] .jp-RenderedHTML:has(> pre) {
   background-color: rgb(41 37 36);
 }

--- a/jupyter-book/_static/custom.css
+++ b/jupyter-book/_static/custom.css
@@ -83,19 +83,21 @@ summary code,
 
 /*
  * An output that ships HTML, such as a MuData object description or a rich console log, is not one of the output types the theme renders itself, so it goes through the notebook renderer and misses the backdrop above.
- * Only a container holding a bare preformatted block is picked up, which is what those descriptions and logs are; tables, widgets and figures keep the layout they bring along.
- * The margin the notebook renderer puts around the block is dropped so that it lines up with the other outputs.
+ * Only a bare preformatted block is picked up, which is what those descriptions and logs are; tables, widgets and figures keep the layout they bring along.
+ * The backdrop goes on the block itself because that is what carries the white background of the notebook renderer; on its container the white would simply sit on top of the grey.
+ * The margin and the padding around it are dropped so that it lines up with the other outputs.
  */
 [data-name="outputs-container"] .jp-RenderedHTML:has(> pre) {
+  padding-right: 0;
+}
+
+[data-name="outputs-container"] .jp-RenderedHTML > pre {
+  margin: 0;
   padding: 0.5rem 0.75rem;
   border-radius: 0.25rem;
   background-color: rgb(245 245 244);
 }
 
-[data-name="outputs-container"] .jp-RenderedHTML > pre {
-  margin: 0;
-}
-
-.dark [data-name="outputs-container"] .jp-RenderedHTML:has(> pre) {
+.dark [data-name="outputs-container"] .jp-RenderedHTML > pre {
   background-color: rgb(41 37 36);
 }


### PR DESCRIPTION
Fixes three regressions from the Jupyter Book v2 migration, all in the inline code and cell output styling of `jupyter-book/_static/custom.css`.

Closes #452, closes #453, closes #454.

## Inline code formatting in code outputs (#452)

The theme renders a text output as `<div data-name="safe-output-text"><code>…</code></div>`, so the `<code>` is not inside a `<pre>` and the inline code rule boxed it on top of the grey backdrop the output already has. Cell output is code already, so `[data-name="outputs-container"] code` joins the elements that opt out of the box.

## Inline code formatting in key takeaway dropdowns (#453)

A key takeaway card is an `<a class="myst-card">` around a paragraph rather than a link inside one, so the exception that keeps links free of the box also took it away from the card text. Cards are excluded from that exception, and the prose colour that the theme drops for link content is put back with `.myst-card code { color: var(--tw-prose-code) }`.

## Code output formatting for MuData object descriptions (#454)

MuData ships its object description as `text/html`, which is not one of the output types the theme renders itself. It goes through the notebook renderer instead and so never reached the `safe-output-*` selectors carrying the grey backdrop. Any output that is a bare preformatted block now gets it, which covers those 23 descriptions and the 56 `rich` console logs elsewhere in the book that were in the same state, while tables, widgets and figures keep the layout they bring along.

## Specificity

The two base inline code rules are wrapped in `:where()` so that they carry no specificity. The dark variant is a class and therefore more specific than the elements that opt out of the box, so without this the box came back on all of them in dark mode — a pre-existing bug that would have undone the first two fixes.

## Verification

Built the book locally and inspected the rendered DOM in Chrome, in light and dark mode:

- card inline code computes identically to prose inline code — `rgb(190, 24, 93)` on `rgb(250, 250, 249)`, same padding and border;
- `<code>` inside an output computes to no padding, no border and a transparent background;
- the MuData block is the same width, padding and grey as every other output on the page.

