### PR TITLE
Expand the whole table of contents in the sidebar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ serve:
 build:
 	cd $(JUPYTER_BOOK_DIR) && jupyter book build --html
 	python3 scripts/postbuild/reload_on_back.py $(JUPYTER_BOOK_DIR)/_build/html
+	python3 scripts/postbuild/expand_toc.py $(JUPYTER_BOOK_DIR)/_build/html
 
 dropdown:
 	python3 scripts/dropdowns/insert_dropdowns.py

--- a/jupyter-book/_static/custom.css
+++ b/jupyter-book/_static/custom.css
@@ -101,3 +101,31 @@ summary code,
 .dark [data-name="outputs-container"] .jp-RenderedHTML > pre {
   background-color: rgb(41 37 36);
 }
+
+/* The theme sizes the table of contents rows for a mostly collapsed tree, but every section is open (see scripts/postbuild/expand_toc.py). */
+.myst-toc {
+  font-size: 0.8125rem;
+  line-height: 1.35;
+}
+
+/* A chapter is the row itself, a section is a row wrapping a title and a chevron. */
+.myst-toc .myst-toc-item {
+  gap: 0.25rem;
+  margin-block: 0;
+  padding-block: 0.25rem;
+}
+
+.myst-toc .myst-toc-item > :where(a, div) {
+  padding-block: 0;
+}
+
+/* The chevron is sized by attributes on the SVG, and sets the height of a section row. */
+.myst-toc .myst-toc-item svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.myst-toc > div > .myst-toc-item {
+  margin-top: 0.5rem;
+  font-weight: 600;
+}

--- a/scripts/postbuild/client_bundle.py
+++ b/scripts/postbuild/client_bundle.py
@@ -1,0 +1,61 @@
+"""Append a client side workaround to the JavaScript bundle of a built site.
+
+The theme is a Remix application that hydrates `<head>` and `<body>`, so a `<script>` tag injected into the built HTML breaks hydration on every page.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ENTRY_GLOB = "entry.client-*.js"
+DEFAULT_ROOT = Path("jupyter-book/_build/html")
+
+
+def patch_client_entry(marker: str, snippet: str, description: str) -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else DEFAULT_ROOT)
+    if not root.is_dir():
+        print(f"{root} does not exist, nothing to patch", file=sys.stderr)
+        return 1
+
+    entries = sorted((root / "build").glob(ENTRY_GLOB))
+    if not entries:
+        print(
+            f"no {ENTRY_GLOB} under {root / 'build'}; the theme's bundle layout changed, "
+            f"so {description} was not applied",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Every page imports the same client entry, so patch the ones a page actually loads.
+    pages = [p for p in root.rglob("*.html") if "/build/" not in p.as_posix()]
+    referenced = {
+        m.group(1)
+        for page in pages
+        for m in re.finditer(
+            r'/build/(entry\.client-[^"\')]+\.js)', page.read_text(encoding="utf-8")
+        )
+    }
+    if not referenced:
+        print("no page imports a client entry bundle", file=sys.stderr)
+        return 1
+
+    patched = 0
+    for entry in entries:
+        if entry.name not in referenced:
+            continue
+        text = entry.read_text(encoding="utf-8")
+        if marker in text:
+            continue
+        entry.write_text(text + snippet, encoding="utf-8")
+        patched += 1
+
+    missing = referenced - {e.name for e in entries}
+    if missing:
+        print(f"pages import missing entry bundles: {sorted(missing)}", file=sys.stderr)
+        return 1
+
+    print(
+        f"{description} applied to {patched} client entry bundle(s), "
+        f"covering {len(pages)} pages"
+    )
+    return 0

--- a/scripts/postbuild/expand_toc.py
+++ b/scripts/postbuild/expand_toc.py
@@ -1,0 +1,78 @@
+"""Open every section of the sidebar table of contents, not just the current one.
+
+The theme has no option for this, and the sections are Radix collapsibles that do not render their children while closed, so CSS cannot reveal them either.
+"""
+
+from client_bundle import patch_client_entry
+
+MARKER = "myst-expand-toc"
+
+SNIPPET = f"""
+/* {MARKER} */
+;(function () {{
+  if (typeof window === "undefined" || window.__mystExpandToc) return;
+  window.__mystExpandToc = true;
+
+  var COLLAPSED = '.myst-toc button[aria-label="Open Folder"][aria-expanded="false"]';
+  var ACTIVE = '.myst-toc [aria-current="page"]';
+  var SCROLLER = ".myst-primary-sidebar-nav";
+  var WINDOW_MS = 2000;
+  var QUIET_FRAMES = 10;
+
+  var deadline = 0;
+  var running = false;
+
+  /* Retried rather than done once: React mounts the sidebar after this runs, and the theme collapses the other sections again on every navigation.
+     Outside the window a reader can collapse a section and have it stay collapsed. */
+  function expand() {{
+    deadline = Date.now() + WINDOW_MS;
+    if (running) return;
+    running = true;
+    var opened = false;
+    var quiet = 0;
+
+    (function pass() {{
+      var collapsed = document.querySelectorAll(COLLAPSED);
+      collapsed.forEach(function (button) {{
+        button.click();
+      }});
+      opened = opened || collapsed.length > 0;
+      quiet = collapsed.length > 0 ? 0 : quiet + 1;
+      if (Date.now() < deadline && !(opened && quiet > QUIET_FRAMES)) {{
+        window.requestAnimationFrame(pass);
+        return;
+      }}
+      running = false;
+      reveal();
+    }})();
+  }}
+
+  /* The expanded tree is taller than the sidebar, so scroll it, and only it, to the chapter being read. */
+  function reveal() {{
+    var active = document.querySelector(ACTIVE);
+    var scroller = active && active.closest(SCROLLER);
+    if (!scroller) return;
+    var entry = active.getBoundingClientRect();
+    var view = scroller.getBoundingClientRect();
+    if (entry.top >= view.top && entry.bottom <= view.bottom) return;
+    scroller.scrollTop += entry.top - view.top - view.height / 3;
+  }}
+
+  ["pushState", "replaceState"].forEach(function (name) {{
+    var original = window.history[name];
+    if (typeof original !== "function") return;
+    window.history[name] = function () {{
+      var result = original.apply(this, arguments);
+      expand();
+      return result;
+    }};
+  }});
+  window.addEventListener("popstate", expand);
+
+  expand();
+}})();
+"""
+
+
+if __name__ == "__main__":
+    raise SystemExit(patch_client_entry(MARKER, SNIPPET, "expanded table of contents"))

--- a/scripts/postbuild/reload_on_back.py
+++ b/scripts/postbuild/reload_on_back.py
@@ -20,17 +20,10 @@ Keying this off the path rather than off a remembered click on a card matters: a
 when the card is clicked is cleared by whatever the reader clicks next, which is easy to
 do between following a takeaway and pressing back.
 
-The listener deliberately goes into the JavaScript bundle rather than into a `<script>`
-tag in the HTML. Remix hydrates `<head>` and `<body>`, so an injected tag is DOM React
-did not render, which breaks hydration on every page — a worse bug than the one being
-worked around.
-
 Remove this once the theme handles POP navigation.
 """
 
-import re
-import sys
-from pathlib import Path
+from client_bundle import patch_client_entry
 
 MARKER = "myst-reload-on-back-workaround"
 
@@ -72,60 +65,6 @@ SNIPPET = f"""
 }})();
 """
 
-ENTRY_GLOB = "entry.client-*.js"
-
-
-def main() -> int:
-    root = Path(sys.argv[1] if len(sys.argv) > 1 else "jupyter-book/_build/html")
-    if not root.is_dir():
-        print(f"{root} does not exist, nothing to patch", file=sys.stderr)
-        return 1
-
-    entries = sorted((root / "build").glob(ENTRY_GLOB))
-    if not entries:
-        print(
-            f"no {ENTRY_GLOB} under {root / 'build'}; the theme's bundle layout changed, "
-            "so the back button workaround was not applied",
-            file=sys.stderr,
-        )
-        return 1
-
-    # Every page imports the same client entry, so patching it covers the whole site.
-    # Guard against the entry being referenced but not actually loaded by checking that
-    # at least one page imports it.
-    pages = [p for p in root.rglob("*.html") if "/build/" not in p.as_posix()]
-    referenced = {
-        m.group(1)
-        for page in pages
-        for m in re.finditer(
-            r'/build/(entry\.client-[^"\')]+\.js)', page.read_text(encoding="utf-8")
-        )
-    }
-    if not referenced:
-        print("no page imports a client entry bundle", file=sys.stderr)
-        return 1
-
-    patched = 0
-    for entry in entries:
-        if entry.name not in referenced:
-            continue
-        text = entry.read_text(encoding="utf-8")
-        if MARKER in text:
-            continue
-        entry.write_text(text + SNIPPET, encoding="utf-8")
-        patched += 1
-
-    missing = referenced - {e.name for e in entries}
-    if missing:
-        print(f"pages import missing entry bundles: {sorted(missing)}", file=sys.stderr)
-        return 1
-
-    print(
-        f"back button workaround applied to {patched} client entry bundle(s), "
-        f"covering {len(pages)} pages"
-    )
-    return 0
-
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    raise SystemExit(patch_client_entry(MARKER, SNIPPET, "back button workaround"))


### PR DESCRIPTION
The v2 sidebar opens only the section holding the current page, so finding a chapter means opening sections one by one. Expands all of them, tightens the rows, and scrolls the sidebar to the current chapter.

The theme has no option for this and the sections are Radix collapsibles that do not render children while closed, so it goes in the client entry bundle next to the existing back button workaround.