### PR TITLE
Fix the release workflow and refresh the GitHub Actions

### DIFF
--- a/.github/workflows/build_book.yml
+++ b/.github/workflows/build_book.yml
@@ -8,9 +8,6 @@ on:
 
 concurrency: preview-${{ github.ref }}
 
-env:
-  PREVIEW_BRANCH: gh-pages
-
 jobs:
   build-book:
     runs-on: ubuntu-latest
@@ -18,7 +15,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: "3.14"
 
@@ -26,18 +23,6 @@ jobs:
         run: |
           pip install uv
           uv pip install --system "jupyter-book==2.1.6" jupytext beautifulsoup4
-
-      - name: Cache jupyter-cache folder
-        uses: actions/cache@v4
-        env:
-          cache-name: jupyter-cache
-        with:
-          path: jupyter-book/_build/.jupyter_cache
-          key: v1-${{ github.ref }}-${{ hashFiles('notebook_scripts/**/*.py') }}
-          restore-keys: |
-            v1-${{ github.ref }}-${{ hashFiles('notebook_scripts/**/*.py') }}
-            v1-${{ github.ref }}
-            v1-refs/heads/master
 
       - name: Insert dropdowns to all chapters
         run: make dropdown
@@ -61,6 +46,18 @@ jobs:
           python -m pip install --upgrade uv
           uv pip install --system jupyter-book==2.1.6 jupytext beautifulsoup4
 
+      - name: Install LaTeX
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            latexmk \
+            texlive-latex-recommended \
+            texlive-latex-extra \
+            texlive-fonts-recommended \
+            texlive-plain-generic \
+            texlive-xetex \
+            texlive-extra-utils
+
       - name: Build PDF
         run: make pdf
 
@@ -68,3 +65,4 @@ jobs:
         with:
           name: PDF_HTML
           path: jupyter-book/exports/book.pdf
+          if-no-files-found: error

--- a/.github/workflows/build_book.yml
+++ b/.github/workflows/build_book.yml
@@ -46,10 +46,12 @@ jobs:
           python -m pip install --upgrade uv
           uv pip install --system jupyter-book==2.1.6 jupytext beautifulsoup4
 
-      - name: Install LaTeX
+      - name: Install LaTeX and the image converters myst shells out to
         run: |
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends \
+            imagemagick \
+            librsvg2-bin \
             latexmk \
             texlive-latex-recommended \
             texlive-latex-extra \

--- a/.github/workflows/build_environments.yml
+++ b/.github/workflows/build_environments.yml
@@ -32,7 +32,7 @@ jobs:
             "jupyter-book/multimodal_integration/advanced_integration.yml",
           ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install Conda environment with Micromamba
         uses: mamba-org/setup-micromamba@v3

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,16 +4,18 @@ on:
   push:
     branches:
       - main
-      - master
 
 jobs:
   labeler:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run Labeler
-        uses: crazy-max/ghaction-github-labeler@v3.1.1
+        uses: crazy-max/ghaction-github-labeler@v6.0.0
         with:
           skip-delete: true

--- a/.github/workflows/publish_book.yml
+++ b/.github/workflows/publish_book.yml
@@ -9,27 +9,17 @@ jobs:
   build-book:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
-          python-version: 3.13
+          python-version: "3.14"
 
       - name: Setup environment
-        run: pip install --upgrade "jupyter-book==2.1.6" jupytext==1.19.3 beautifulsoup4==4.15.0
-
-      - name: Cache jupyter-cache folder
-        uses: actions/cache@v4
-        env:
-          cache-name: jupyter-cache
-        with:
-          path: jupyter-book/_build/.jupyter_cache
-          key: v1-${{ github.ref }}-${{ hashFiles('notebook_scripts/**/*.py') }}
-          restore-keys: |
-            v1-${{ github.ref }}-${{ hashFiles('notebook_scripts/**/*.py') }}
-            v1-${{ github.ref }}
-            v1-refs/heads/master
+        run: |
+          pip install uv
+          uv pip install --system "jupyter-book==2.1.6" jupytext beautifulsoup4
 
       - name: Insert dropdowns to all chapters
         run: make dropdown

--- a/.github/workflows/release_drafter.yml
+++ b/.github/workflows/release_drafter.yml
@@ -13,7 +13,10 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v7
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Aligns `publish_book.yml` with the build CI so releases deploy the configuration that CI actually validates, removes the jupyter-cache step that never saved anything, and makes the PDF job install LaTeX and fail when no PDF is produced instead of passing silently.
Also bumps the stale actions in the labeler, release drafter and environment workflows to their current major versions.