### PR TITLE
Explain why the dimensionality reduction chapter does not scale genes

### DIFF
--- a/jupyter-book/preprocessing_visualization/dimensionality_reduction.ipynb
+++ b/jupyter-book/preprocessing_visualization/dimensionality_reduction.ipynb
@@ -178,7 +178,22 @@
     "\n",
     "PCA offers the advantage that it is highly interpretable and computationally efficient.\n",
     "However, as scRNA-seq datasets are rather sparse due to dropout events and therefore highly non-linear, visualization with the linear dimensionality reduction technique PCA is not very appropriate.\n",
-    "PCA is typically used to select the top 10-50 PCs, which are used for downstream analysis tasks."
+    "PCA is typically used to select the top 10-50 PCs, which are used for downstream analysis tasks.\n",
+    "\n",
+    "```{admonition} Should you scale genes before PCA?\n",
+    ":class: dropdown\n",
+    "\n",
+    "Many tutorials z-score every gene to zero mean and unit variance before running PCA, and we deliberately do not.\n",
+    "Scaling weights all genes equally in the components that follow, so a lowly expressed gene can contribute as much variance as a strongly expressed one.\n",
+    "Refraining from it keeps the magnitude of expression as a proxy for how informative a gene is.\n",
+    "\n",
+    "There is no consensus on which of the two is correct.\n",
+    "The choice comes down to whether all genes should count equally for downstream analysis, or whether the magnitude of expression is itself informative, and we opt for the latter to retain as much biological signal as possible.\n",
+    "Selecting highly deviant genes beforehand already restricts the components to genes that vary meaningfully across cells.\n",
+    "\n",
+    "This is separate from centering.\n",
+    "`sc.pp.pca` centers the data internally, so PCA is well defined without a preceding scaling step.\n",
+    "```"
    ]
   },
   {


### PR DESCRIPTION
Adds a dropdown admonition next to the PCA section covering what gene scaling changes, why the chapter refrains from it, and that centering is handled by `sc.pp.pca` itself.

Closes #185