### PR TITLE
Address the prose review points on the quality control chapter

### DIFF
--- a/jupyter-book/preprocessing_visualization/quality_control.ipynb
+++ b/jupyter-book/preprocessing_visualization/quality_control.ipynb
@@ -85,7 +85,7 @@
    "metadata": {},
    "source": [
     "Although single-cell count matrix preprocessing is generally a linear process where various quality control and preprocessing steps are conducted in a clear order, the introduction of specific steps here requires us to sometimes jump ahead to steps that we are going to introduce in one of the later subchapters.\n",
-    "For example, we make use of clustering for the ambient RNA correction, but will only introduce clustering later."
+    "For example, we make use of clustering for the ambient RNA correction, but will only introduce [clustering](../cellular_structure/clustering.ipynb) later."
    ]
   },
   {
@@ -254,7 +254,7 @@
     "\n",
     "In cell QC these covariates are filtered via thresholding as they might correspond to dying cells.\n",
     "As indicated, they might reflect cells with broken membranes whose cytoplasmic mRNA has leaked out, and therefore only the mRNA in the mitochondria is still present.\n",
-    "These cells might then show a low count depth, few detected genes, and a high fraction of mitochondrial reads.\n",
+    "These cells might then show a low count depth, few detected genes, and a high fraction of mitochondrial counts.\n",
     "It is, however, crucial to consider the three QC covariates jointly as otherwise, it might lead to misinterpretation of cellular signals.\n",
     "Cells with a relatively high fraction of mitochondrial counts might for example be involved in respiratory processes and should not be filtered out.\n",
     "Whereas, cells with low or high counts might correspond to quiescent cell populations or cells larger in size.\n",
@@ -272,7 +272,13 @@
     "We therefore define mitochondrial, ribosomal, and hemoglobin genes.\n",
     "It is important to note that mitochondrial counts are annotated either with the prefix \"mt-\" or \"MT-\" depending on the species considered in the dataset.\n",
     "As mentioned, the dataset used in this notebook is human bone marrow, so mitochondrial counts are annotated with the prefix \"MT-\".\n",
-    "For mouse datasets, the prefix is usually in lower case, so \"mt-\"."
+    "For mouse datasets, the prefix is usually in lower case, so \"mt-\".\n",
+    "Matching on the gene symbol prefix is only one way to find these genes, and it relies on the annotation the dataset happens to ship with.\n",
+    "Where symbols are missing or follow a different convention, mitochondrial genes can be selected from the chromosome each gene is annotated to, or from a curated list of gene identifiers.\n",
+    "\n",
+    "Ribosomal and hemoglobin genes are defined here as additional diagnostics rather than as filtering criteria.\n",
+    "A high fraction of hemoglobin counts points at contamination with red blood cells, and the ribosomal fraction varies with cell state and can help explain what separates clusters later on.\n",
+    "Neither enters the filtering below, which uses the count depth, the number of detected genes and the mitochondrial fraction."
    ]
   },
   {
@@ -403,7 +409,7 @@
    "metadata": {},
    "source": [
     "The plots indicate that some cells have a relatively high percentage of mitochondrial counts which are often associated with cell degradation.\n",
-    "But since number of counts per cell is sufficiently high and the percentage of mitochondrial reads is for most cells below 20 % we can still process the data.\n",
+    "But since the number of counts per cell is sufficiently high and the percentage of mitochondrial counts is for most cells below 20 % we can still process the data.\n",
     "Based on these plots, one could now also define manual thresholds for filtering cells.\n",
     "Instead, we will show QC with automatic thresholding and filtering based on MAD.\n",
     "\n",
@@ -467,7 +473,7 @@
    "id": "8a975c59-a91e-4449-972f-a9b6b2526225",
    "metadata": {},
    "source": [
-    "`pct_counts_Mt` is filtered with 3 MADs.\n",
+    "`pct_counts_mt` is filtered with 3 MADs.\n",
     "Additionally, cells with a percentage of mitochondrial counts exceeding 8 % are filtered out."
    ]
   },
@@ -563,6 +569,10 @@
    "source": [
     "## Correction of ambient RNA\n",
     "\n",
+    "Unlike the filtering above, correcting for ambient RNA is not part of every analysis, and it only applies to droplet-based protocols.\n",
+    "We cover it here because the contamination it describes violates the same one droplet, one cell assumption as the doublets discussed further below.\n",
+    "Whether it is worth applying depends on how much contamination a dataset carries and on how sensitive the downstream analysis is to it.\n",
+    "\n",
     "For droplet-based single cell RNA-seq experiments, a certain amount of background mRNAs is present in the dilution that gets distributed into the droplets with cells and sequenced along with them.\n",
     "The net effect of this is to produce a background contamination that represents expression not from the cell contained within a droplet, but the solution that contained the cells.\n",
     "\n",
@@ -584,7 +594,7 @@
     ":::\n",
     "\n",
     "Cell-free mRNA molecules, also known as ambient RNA, can confound the number of observed counts and can be seen as background contamination.\n",
-    "It is important to correct droplet-based scRNA-seq datasets for cell-free mRNA as it may distort the interpretation of the data in our downstream analysis.\n",
+    "It can be important to correct droplet-based scRNA-seq datasets for cell-free mRNA as it may distort the interpretation of the data in our downstream analysis.\n",
     "Generally, the soup differs for each input solution and depends on the expression pattern across individual cells in the dataset.\n",
     "Methods for removal of ambient mRNA like SoupX {cite:p}`qc:Young2020` and DecontX {cite:p}`qc:decontX_yang_decontamination_2020` aim to estimate the composition of the soup and correct the count table with respect to the soup-based expression.\n",
     "\n",
@@ -658,7 +668,7 @@
     "We will showcase the latter in this notebook as the results from SoupX are not strongly sensitive to the clustering used. \n",
     "\n",
     "We now create a copy of our AnnData object, normalize it, reduce its dimensionality and compute default Leiden clusters on the processed copy.\n",
-    "A subsequent chapter introduces clustering in more detail.\n",
+    "The [clustering chapter](../cellular_structure/clustering.ipynb) introduces clustering in more detail.\n",
     "For now, we just need to know that Leiden clustering gives us partitions (communities) of cells in our dataset.\n",
     "We save the obtained clusters as `soupx_groups` and delete the copy of the AnnData object to save some memory in our notebook.  \n",
     "\n",


### PR DESCRIPTION
Covers the items from #248 that do not change any results: why the mitochondrial prefix is only one selection method, why ribosomal and hemoglobin genes are computed without being filtered on, that ambient RNA correction is not a universal step, the two missing links to the clustering chapter, and the reads/counts and `pct_counts_Mt` typos.

The remaining items there (the two-tailed `is_outlier`, plotting the thresholds, and the logit transform for the mitochondrial fraction) change the filtering results and need a re-execution, so they are left open.