### PR TITLE
Require both mitochondrial criteria instead of either

### DIFF
--- a/jupyter-book/preprocessing_visualization/quality_control.ipynb
+++ b/jupyter-book/preprocessing_visualization/quality_control.ipynb
@@ -413,7 +413,10 @@
     "Based on these plots, one could now also define manual thresholds for filtering cells.\n",
     "Instead, we will show QC with automatic thresholding and filtering based on MAD.\n",
     "\n",
-    "First, we define a function that takes a `metric`, i.e. a column in `.obs` and the number of MADs (`nmad`) that is still permissive within the filtering strategy."
+    "First, we define a function that takes a `metric`, i.e. a column in `.obs`, the number of MADs (`nmads`) that is still permissive within the filtering strategy, and the direction in which an outlier is suspicious.\n",
+    "Which direction that is depends on the metric.\n",
+    "A cell with an unusually high mitochondrial fraction may be dying, while one with an unusually low fraction is not a low quality cell, so that covariate is only filtered from above.\n",
+    "The count depth and the number of detected genes are filtered in both directions, since both very low and very high values warrant a closer look."
    ]
   },
   {
@@ -423,12 +426,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def is_outlier(adata, metric: str, nmads: int):\n",
+    "def is_outlier(adata, metric: str, nmads: int, side: str = \"both\"):\n",
     "    M = adata.obs[metric]\n",
-    "    outlier = (M < np.median(M) - nmads * median_abs_deviation(M)) | (\n",
-    "        np.median(M) + nmads * median_abs_deviation(M) < M\n",
-    "    )\n",
-    "    return outlier"
+    "    below = M < np.median(M) - nmads * median_abs_deviation(M)\n",
+    "    above = np.median(M) + nmads * median_abs_deviation(M) < M\n",
+    "    if side == \"above\":\n",
+    "        return above\n",
+    "    if side == \"below\":\n",
+    "        return below\n",
+    "    return below | above"
    ]
   },
   {
@@ -473,8 +479,11 @@
    "id": "8a975c59-a91e-4449-972f-a9b6b2526225",
    "metadata": {},
    "source": [
-    "`pct_counts_mt` is filtered with 3 MADs.\n",
-    "Additionally, cells with a percentage of mitochondrial counts exceeding 8 % are filtered out."
+    "`pct_counts_mt` is filtered with 3 MADs, from above only.\n",
+    "A cell is marked here only if it is flagged by that rule and its mitochondrial fraction also exceeds 8 %, as in {cite:p}`qc:germain_pipecomp_2020`.\n",
+    "Requiring both rather than either keeps the filtering permissive, which is what the rest of this chapter argues for.\n",
+    "The 8 % itself is not a universal cutoff.\n",
+    "Cell types differ substantially in mitochondrial content, so the threshold depends on the tissue at hand and is worth revisiting once the cells have been annotated."
    ]
   },
   {
@@ -498,7 +507,7 @@
     }
    ],
    "source": [
-    "adata.obs[\"mt_outlier\"] = is_outlier(adata, \"pct_counts_mt\", 3) | (\n",
+    "adata.obs[\"mt_outlier\"] = is_outlier(adata, \"pct_counts_mt\", 3, side=\"above\") & (\n",
     "    adata.obs[\"pct_counts_mt\"] > 8\n",
     ")\n",
     "adata.obs.mt_outlier.value_counts()"


### PR DESCRIPTION
Switches the mitochondrial outlier rule from `|` to `&`, matching the source the chapter cites, and gives `is_outlier` a direction so the mitochondrial fraction is only filtered from above.

Draft because the notebook has not been re-executed, so its committed outputs still show the cell counts produced by the old rule.

Refs #170, refs #248