### PR TITLE
Stop presenting an underflowed p-value as a p-value of zero

### DIFF
--- a/jupyter-book/spatial/spatially_variable_genes.ipynb
+++ b/jupyter-book/spatial/spatially_variable_genes.ipynb
@@ -259,7 +259,12 @@
    "id": "0671c32d-d5be-4f61-98cf-08fae6731d1b",
    "metadata": {},
    "source": [
-    "Let us look at two of the identified and significant genes, for example *Nrgn* and *Ttr* with corrected p-values of 0.0."
+    "Let us look at two of the identified and significant genes, for example *Nrgn* and *Ttr*.\n",
+    "The table reports corrected p-values of 0.0 for both, which is a property of the representation rather than a result.\n",
+    "A p-value cannot be exactly zero, and what happened here is that the value fell below the smallest positive number double precision can hold and underflowed, so these entries should be read as smaller than anything the table can display.\n",
+    "\n",
+    "The p-values here are computed analytically under a normality assumption, which puts no lower bound on how small they can get.\n",
+    "Passing `n_perms` to `spatial_autocorr` estimates them by permutation instead, where the number of permutations bounds how small a p-value can be reported."
    ]
   },
   {


### PR DESCRIPTION
The spatially variable genes chapter described *Nrgn* and *Ttr* as having corrected p-values of 0.0. The text now explains that squidpy's analytic p-value underflowed the double precision representation, and points at `n_perms` as the permutation alternative whose resolution is bounded by the number of permutations.

Closes #364